### PR TITLE
fix for issues #630 #691 and #692

### DIFF
--- a/thonny/running.py
+++ b/thonny/running.py
@@ -278,6 +278,10 @@ class Runner:
         
         filename = get_saved_current_script_filename()
 
+        if not filename:
+            # cancel must have been pushed
+            return
+
         # changing dir may be required
         script_dir = normpath_with_actual_case(os.path.dirname(filename))
 

--- a/thonny/shell.py
+++ b/thonny/shell.py
@@ -206,6 +206,7 @@ class ShellText(EnhancedTextWithLogging, PythonText):
         self._try_submit_input()
 
     def _handle_input_request(self, msg):
+        self._ensure_visible()
         self.focus_set()
         self.mark_set("insert", "end")
         self.tag_remove("sel", "1.0", tk.END)

--- a/thonny/shell.py
+++ b/thonny/shell.py
@@ -676,9 +676,11 @@ class ShellText(EnhancedTextWithLogging, PythonText):
 
         if (
             len(self._command_history) == 0
-            or self._command_history_current_index == len(self._command_history) - 1
+            or self._command_history_current_index >= len(self._command_history) - 1
         ):
             # can't take next command
+            self._command_history_current_index = len(self._command_history)
+            self._propose_command("")
             return "break"
 
         if self._command_history_current_index is None:


### PR DESCRIPTION
The cause for the error crashing when canceling the save dialog when running a new program was that there is no check that the filename was actually assigned.   