### PR TITLE
When saving a file, respect the original fileformat.

### DIFF
--- a/thonny/code.py
+++ b/thonny/code.py
@@ -48,6 +48,7 @@ class Editor(ttk.Frame):
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)
 
+        self._newlines = None
         self._filename = None
         self._last_known_mtime = None
         self._asking_about_external_change = False
@@ -157,6 +158,9 @@ class Editor(ttk.Frame):
         with tokenize.open(filename) as fp:  # TODO: support also text files
             source = fp.read()
 
+        # get the file file format (DOS/UNIX)
+        self._newlines = fp.newlines
+
         # Make sure Windows filenames have proper format
         filename = normpath_with_actual_case(filename)
         self._filename = filename
@@ -241,7 +245,7 @@ class Editor(ttk.Frame):
             self._filename = new_filename
             get_workbench().event_generate("SaveAs", editor=self, filename=new_filename)
 
-        content = self._code_view.get_content_as_bytes()
+        content = self._code_view.get_content_as_bytes(self._newlines == '\r\n')
         try:
             f = open(self._filename, mode="wb")
             f.write(content)

--- a/thonny/codeview.py
+++ b/thonny/codeview.py
@@ -255,9 +255,9 @@ class CodeView(tktextext.TextFrame):
         )
         return encoding
 
-    def get_content_as_bytes(self):
+    def get_content_as_bytes(self, in_DOS_fileformat = False):
         chars = self.get_content().replace("\r", "")
-        if running_on_windows():
+        if running_on_windows() or in_DOS_fileformat:
             chars = chars.replace("\n", "\r\n")
 
         return chars.encode(self.detect_encoding())


### PR DESCRIPTION
This is done by:

- capturing the fileformat with attribute newlines
- get_content_in_bytes optionally provides windows format