### PR TITLE
respect fileformat for unix files too

### DIFF
--- a/thonny/code.py
+++ b/thonny/code.py
@@ -245,7 +245,7 @@ class Editor(ttk.Frame):
             self._filename = new_filename
             get_workbench().event_generate("SaveAs", editor=self, filename=new_filename)
 
-        content = self._code_view.get_content_as_bytes(self._newlines == '\r\n')
+        content = self._code_view.get_content_as_bytes(self._newlines)
         try:
             f = open(self._filename, mode="wb")
             f.write(content)

--- a/thonny/codeview.py
+++ b/thonny/codeview.py
@@ -255,10 +255,11 @@ class CodeView(tktextext.TextFrame):
         )
         return encoding
 
-    def get_content_as_bytes(self, in_DOS_fileformat = False):
+    def get_content_as_bytes(self, newlines):
+        newlines_windows = "\r\n"
         chars = self.get_content().replace("\r", "")
-        if running_on_windows() or in_DOS_fileformat:
-            chars = chars.replace("\n", "\r\n")
+        if newlines == None and running_on_windows() or newlines == newlines_windows:
+            chars = chars.replace("\n", newlines_windows)
 
         return chars.encode(self.detect_encoding())
 


### PR DESCRIPTION
There is another issue with file formats. When editing on windows files with unix fileformat, they were overwritten with DOS fileformat. This should not happen neither.

For fixing that:
- on `get_content_as_bytes`, pass the newline format without comparing it (it's `None` by default)
- modify the condition to save on windows file format

I have tested this both on windows and linux machines.

Let me know if you have comments regarding coding style etc.