### PR TITLE
default value of None

### DIFF
--- a/thonny/codeview.py
+++ b/thonny/codeview.py
@@ -255,7 +255,7 @@ class CodeView(tktextext.TextFrame):
         )
         return encoding
 
-    def get_content_as_bytes(self, newlines):
+    def get_content_as_bytes(self, newlines = None):
         newlines_windows = "\r\n"
         chars = self.get_content().replace("\r", "")
         if newlines == None and running_on_windows() or newlines == newlines_windows:


### PR DESCRIPTION
There is a call to get_content_as_bytes without a parameter, therefore the default value of None should be set. Otherwise there would be a runtime error.

Sorry for so many pull requests, I thought my pull request was a draft.