### PR TITLE
Page down to end of shell text when focusing

### DIFF
--- a/thonny/workbench.py
+++ b/thonny/workbench.py
@@ -1812,6 +1812,10 @@ class Workbench(tk.Tk):
 
     def _cmd_focus_shell(self) -> None:
         self.show_view("ShellView", True)
+        shell = self.get_view("ShellView")
+        # go to the end of any current input
+        shell.text.mark_set("insert", "end")
+        shell.text.see("insert")
 
     def _cmd_toggle_full_screen(self) -> None:
         """


### PR DESCRIPTION
Fixes #749

new at "Tkintering", I hope this is enough behaviour to work correctly. Unless you need something to add a prompt in some situations? 🤔 Not sure.