### PR TITLE
French help

### DIFF
--- a/thonny/plugins/help/__init__.py
+++ b/thonny/plugins/help/__init__.py
@@ -3,10 +3,10 @@ import tkinter as tk
 import tkinter.font
 from tkinter import ttk
 
-from thonny import get_workbench, rst_utils, tktextext, ui_utils
+from thonny import get_workbench, rst_utils, tktextext, ui_utils, CONFIGURATION_FILE_NAME
+from thonny.config import try_load_configuration
 from thonny.tktextext import TextFrame
 from thonny.ui_utils import scrollbar_style
-
 
 class HelpView(TextFrame):
     def __init__(self, master):
@@ -24,7 +24,11 @@ class HelpView(TextFrame):
             pady=0,
             read_only=True,
         )
-
+        # retrieve the directory of the preferred language
+        # for help's .rst files ; this directory is ./ by default
+        self.languageDir="."
+        self._configuration_manager = try_load_configuration(CONFIGURATION_FILE_NAME)
+        self.languageDir=self._configuration_manager.get_option("general.language",".")
         self.load_rst_file("index.rst")
 
     def load_topic(self, topic, fragment=None):
@@ -35,10 +39,14 @@ class HelpView(TextFrame):
         self.text.clear()
         self.text.direct_insert("1.0", "\n")
 
+        # try to access filename in a language subdirectory
         if not os.path.isabs(filename):
-            filename = os.path.join(os.path.dirname(__file__), filename)
+            filename1 = os.path.join(os.path.dirname(__file__), self.languageDir, filename)
+        if not os.path.exists(filename1):
+            # if the localized file does not exist, default to English
+            filename1 = os.path.join(os.path.dirname(__file__), filename)
 
-        with open(filename, encoding="UTF-8") as fp:
+        with open(filename1, encoding="UTF-8") as fp:
             self.text.append_rst(fp.read())
 
 

--- a/thonny/plugins/help/__init__.py
+++ b/thonny/plugins/help/__init__.py
@@ -55,5 +55,5 @@ def open_help():
 
 
 def load_plugin() -> None:
-    get_workbench().add_view(HelpView, "Help", "ne")
-    get_workbench().add_command("help_contents", "help", "Help contents", open_help, group=30)
+    get_workbench().add_view(HelpView, _("Help"), "ne")
+    get_workbench().add_command("help_contents", "help", _("Help contents"), open_help, group=30)

--- a/thonny/plugins/help/fr_FR/birdseye.rst
+++ b/thonny/plugins/help/fr_FR/birdseye.rst
@@ -1,0 +1,26 @@
+`Accueil <index.rst>`_
+
+L'œil d'oiseau (Birdseye)
+=========================
+
+L'Œil d'oiseau est un débogueur Python vraiment *cool* créé par Alex Hall, qui enregistre les valeurs des expressions
+quand le programme fonctionne et vous laisse les explorer quand le programme se termine. Voir `https://birdseye.readthedocs.io <https://birdseye.readthedocs.io>`_ pour en savoir plus.
+
+L'Œil d'oiseau n'est pas installé par défaut, mais il est facile de l'installer via *Outils → Gérer les greffons*. Il faut
+installer la paquet nommé ``birdseye``.
+
+L'Œil d'oiseau fonctionne d'une façon différente des `débogueurs intégrés à Thonny <debuggers.rst>`_.
+Quand on exécute son programme avec *Lancer → Débogage du script courant (Œil d'oiseau)*, l'exécution est un peut plus
+longue qu'à l'habitude, mais autrement le programme fonctionne exactement comme si on l'avait exécuté avec
+*Lancer le script courant*. Ça signifie que les points d'arrêt sont ignorés et qu'on ne peut pas se déplacer pas-à-pas dans le programme.
+Mais quand le programme se termine, Thonny ouvre une page web (servie localement par Œil d'oiseau),
+qui vous permet de creuser le processus d'exécution et d'apprendre comment ils résultats finaux ont été composés
+à partir des valeurs intermédiaires.
+
+N.B. ! Quand vous utilisez Œil d'oiseau dans Thonny il n'y a pas besoin d'importer ``birdseye.eye`` ou de l'utiliser pour
+décorer vos fonctions. Thonny exécute Œil d'oiseau d'une façon telle qu'il enregistre des informations pour toutes les
+fonctions.
+
+Le serveur local utilise le port 7777 par défaut. Si celui-ci est utilisé par une autre application, alors on peut configurer
+un autre port (Outils → Options → Débogueur) et redémarrer Thonny.
+

--- a/thonny/plugins/help/fr_FR/debuggers.rst
+++ b/thonny/plugins/help/fr_FR/debuggers.rst
@@ -1,0 +1,70 @@
+`Accueil <index.rst>`_
+
+Utilisation des débogueurs
+==========================
+
+Si vous voulez voir comment Python exécute votre programme pas-à-pas alors
+il faut le lancer en *mode de débogage* « joli » ou « vite fait ». On peut
+aussi le faire à l'aide d'`Œil d'oiseau (Birdseye) <birdseye.rst>`_ et
+examiner les étapes d'exécution plus tard.
+
+Le mode « joli »
+----------------
+
+Ce mode est recommandé pour les néophytes.
+
+Commencez par sélectionner *Déboguer le script courant (joli)* depuis le
+menu *Lancer* ou en appuyant sur les touches Ctrl+F5
+(`sous XFCE il faut utiliser Shift+Ctrl+F5 <https://askubuntu.com/questions/92759/ctrlf5-in-google-chrome-in-xfce>`__).
+Vous verrez que la première instruction du programme est mise en valeur et que rien d'autre ne se passe.
+Dans ce mode il faut notifier Thonny qu'on est prêt à laisser Python faire le pas suivant.
+Pour cela, vous avez deux option principales :
+
+* *Lancer → Sauter par dessus* (ou F6) pour faire de grands pas, c'est à dire qu'il exécute le code en évidence puis met en évidence la suite du code.
+* *Lancer → Sauter dedans* (ou F7) pour essayer de faire des pas plus petits. Si le code en évidence est composé de morceaux plus petits (déclaration ou instruction), alors la première est mis en valeur et Thonny attend votre commande suivante. Si on est arrivé à un composant du programme qui ne se décompose pas, (p. ex. un nom de variable), alors *Sauter dedans* se comporte comme *Sauter par dessus* c'est à dire qu'il exécute (ou évalue) le code.
+
+Si on a avancé pas-à-pas dans les profondeurs d'une fonction ou d'une expression et qu'on veut avancer plus vite, on peut alors utiliser *Lancer → Ressortir* qui exécute le code couramment mis en valeur et toutes les parties du programme sur le même niveau.
+Il y a une commande un peu similaire nommée *Reprendre*, qui lancera la commande sans s'arrêter à chaque pas jusqu'à ce qu'elle se termine (ou jusqu'au nouveau point d'arrêt, vois ci-dessous).
+
+Si par accident vous avez fait un trop grand pas et survolé une partie intéressante du code, 
+on peut **défaire cette étape** en sélectionnant *Lancer → Un pas en arrière*. Thonny montrera l'état du programme tel qu'il était avant le dernier pas. Ensuite on peut continuer avec de petits pas
+et zoomer ce morceau de code. (Comment ça marche ? Même quand on réalise un grand pas, Thonny
+enregistre tous les états intermédiaires du programme, qu'il peut rejouer si on fait un pas en arrière.)
+
+Si on veut atteindre une portion spécifique du code, on peut aller plus vite en plaçant le curseur sur cette ligne et en sélectionnant *Lancer → Exécuter jusqu'au curseur*.
+Cela fait avancer Thonny automatiquement en mode pas-à-pas jusqu'à cette ligne. Vous pouvez reprendre la main à partir de là.
+
+Si vous avez activé les numéros de ligne dans l'éditeur (Outils → Options → Éditeur), alors 
+on peut aussi utiliser des **points d'arrêt**. Quand on double-clique dans la marque gauche de l'éditeur près d'une ligne, un point
+apparaît. Alors, quand on lance le débogueur, il ne s'arrête pas avant la première ligne mais va jusqu'à
+la ligne marquée d'un point, qu'on nomme aussi un point d'arrêt. On peut placer autant de points d'arrêt dans le programme
+qu'il en faut. Les points d'arrêt peuvent être retirés en cliquant-double dessus.
+
+
+Le mode « vite fait »
+---------------------
+
+Quand votre programme devient plus gros, on observe que le parcours en mode « joli » prend beaucoup de temps.
+C'est parce que les ornements (p. ex. la possibilité de faire de petits pas durant l'évaluation d'expressions et de revenir en arrière)
+nécessitent une machinerie lourde et lente.
+
+Avec *Débogage du script courant (vite) on perd les ornements mais on peut avancer dans le programme beaucoup plus vite.
+On peut utiliser les mêmes commandes (sauf « Un pas en arrière » comme avec le débogueur en mode joli. C'est le style de débogage que la plupart des programmeurs
+professionnels utilisent d'habitude.
+
+
+Des styles différents pour la présentation de la pile d'appel
+-------------------------------------------------------------
+
+Par défaut Thonny utilise des fenêtres empilées pour représenter la pile d'appels. Cela donne une bonne intuition du
+concept, mais ça devient encombrant à l'usage. C'est pourquoi, depuis la version 3.0 on peut choisir entre
+deux styles différents pour présenter la pile d'appels. Dans « Outils → Options → Débogueur » on peut passer à
+un style plus traditionnel avec une vue séparée pour présenter les trames d'appels. Notez que les deux
+styles sont utilisables, avec chacun des deux modes de débogage.
+
+
+L'œil d'oiseau (Birdseye)
+-------------------------
+
+La commande *Débogage du script courant (Œil d'oiseau)* est expliquée dans une `page séparée <birdseye.rst>`_
+ 

--- a/thonny/plugins/help/fr_FR/debugging.rst
+++ b/thonny/plugins/help/fr_FR/debugging.rst
@@ -1,0 +1,96 @@
+`Accueil <index.rst>`_
+
+Les techniques de débogage
+==========================
+
+Si votre programme ne fonctionne pas, pas de panique ! Vous avez plusieurs
+possibilités pour corriger la situation. Par exemple :
+
+* La faire corriger par quelqu'un d'autre ;
+* Changer *quelque chose* dans le code et réessayer ;
+* Approcher le problème en deux phases : 1) diagnostiquer le problème et 2) le réparer.
+
+  Demander de l'aide peut être une très bonne idée, mais elle ne vous procurera pas cette douce sensation de réussite.
+De toute façon, c'est mieux de ne pas y recourir sans avoir d'abord tenté quelque chose vous-même.
+
+Si vos programmes sont petits, vous pourriez toucher le jackpot en changeant quelque chose au hasard et
+en recommençant (plusieurs fois), mais vous allez perdre même si vous gagnez, comme vous n'en aurez rien appris.
+
+Si vous voulez devenir bon en programmation, il vous faut vraiment approcher le problème de façon plus
+systématique. Entre autres choses, ça signifie que vous devez trouver la raison pour laquelle votre programme dysfonctionne
+avant d'essayer de le corriger. Le processus consistant à trouver la source du problème se nomme *débogage*.
+
+
+Tracer le flux du programme / penser en même temps que Python
+-------------------------------------------------------------
+
+Le plus souvent votre programme n'est pas entièrement mauvais. Il peut y avoir une faute de frappe quelque part ou vous avez manqué
+ou mal compris quelque chose. *N.B. ! Ne prenez pas l'habitude de penser que Python vous a mal compris -- c'est une machine qui ne cherche pas à vous comprendre*. La clé du débogage c'est de trouver précisément où
+et quand vos conceptions du comportement du programme divergent du comportement réel.
+
+Si votre programme affiche une réponse finale fausse cela vous dit quelque chose au sujet
+du comportement du programme, mais ce n'est généralement pas assez pour localiser le problème précisément. Il faut aussi vérifier
+lesquelles des **étapes intermédiaires** sont en accord avec vos conceptions et lesquelles non.
+
+Une technique évidente (et très utile) est d'ajouter des **directives d'affichage en plus** dans le code, qui vous diront
+où en est Python et ce qu'il a fait jusque-là, par exemple :
+
+.. code::
+
+	print("amis avant la boucle-for", amis)
+
+N.B. ! Quelquefois il faut introduire de nouvelles variables et décomposer des expressions complexes en parties plus simples afin
+d'afficher des informations plus détaillées.
+
+Bien que le débogage à base d'affichages soit utilisé aussi par des professionnels (il leur arrive de l'appeler *logging*, journalisation), il y a une alternative,
+qui est plus confortable dans la plupart des cas. Elle s'appelle **avancer pas-à-pas dans le code** et c'est le pain béni de Thonny. Allez au chapitre `Utilisation des débogueurs <debuggers.rst>`_ pour en apprendre plus.
+
+
+Revue du code
+-------------
+
+Une autre technique utile est la revue de code. Cela revient à peu près à tracer le flux du programme, mais on le fait dans sa
+tête et on essaie de visualiser une figure plus grande au lieu de suivre des petits pas.
+
+Voyez chacune des expressions de votre code et essayez de comprendre son rôle et comment elle est reliée à votre tâche.
+
+Pour chaque **variable** demandez-vous :
+
+* Est-ce que le nom de la variable dit ce qu'elle fait ? Vaut-il mieux utiliser un nom au singulier ou au pluriel ?
+* Quel type de valeurs peut se trouver dans cette variable ? Chaînes, entiers, listes de chaînes, liste de flottants, ... ?
+* Quel est le rôle de cette variable ? est-elle  prévue pour être mise à jour de façon répétée de façon à contenir quelque information utile ? est-elle prévue pour utiliser la même information à plusieurs endroits et éviter le copier-coller ? Quoi d'autre ?
+
+Pour chaque **boucle** demandez-vous :
+
+* Comment savez-vous que la boucle est nécessaire ?
+* Combien de fois le corps de la boucle doit-il être exécuté ? De quoi cela dépend-il ?
+* Quel code devrait être dans la boucle et quel code devrait être dehors ?
+* Que faut-il faire avant la boucle et que faut-il faire après ?
+
+Pour chaque **expression** complexe demandez-vous :
+
+* Dans quel ordre devraient se faire les étapes d'évaluation de cette expression ? Est-ce que Python fait ainsi ? En cas de doute, utilisez le débogueur ou introduisez des variables auxiliaires et décomposez l'expression en morceaux plus petits.
+* Quel type de valeur est censé sortir de cette expression ? Chaîne ? Liste de chaînes ?
+
+Il vous manque peut-être des parties importantes dans votre programme :
+
+* Votre tâche nécessite-t-elle de traiter des situations différente différemment ? Si oui, vous avez probablement besoin d'une construction conditionnelle (**if**) ;
+* Votre tâche nécessite-t-elle de faire quelque chose plusieurs fois ? Si oui, il vous faut probablement une boucle.
+
+
+Encore perdu ?
+--------------
+
+« Trouvez-vous l'emplacement ou vos suppositions deviennent fausses » -- ceci est plus simple à dire qu'à faire. Dans le cas de
+programmes complexes c'est facile d'arriver à la situation où vous n'êtes plus du tout sûr de savoir ce que vous supposez
+ni pourquoi vous avez commencé ce fichu programme.
+
+Dans ce cas c'est utile de simplifier votre tâche autant que possible et d'essayer d'implémenter les problèmes plus simples
+en premier. Prenez un autre éditeur, et soit recommencez depuis le début, soit copiez le code existant en jetant tout ce qui
+n'est pas essentiel à votre problème. Par exemple, vous pouvez supposer que l'utilisateur est coopératif et saisit toujours de « bonnes » données.
+Si la tâche implique de faire quelque chose de façon répétitive, alors jetez la partie « répétitive », si la tâche implique
+une condition complexe pour faire quelque chose, rendez la condition plus simple, etc.
+
+Après avoir résolu le problème plus simple vous serez bien mieux équipé pour résoudre aussi la tâche d'origine aussi bien.
+
+

--- a/thonny/plugins/help/fr_FR/dock.rst
+++ b/thonny/plugins/help/fr_FR/dock.rst
@@ -1,0 +1,18 @@
+`Accueil <index.rst>`_
+
+Ancrer les fenêtres utilisateur
+===============================
+
+Quand on développe son programme Turtle (ou utilisant Tkinter), on peut vouloir regarder la fenêtre
+de l'essai précédent tout en réparant quelques lignes de code. Si on a des écrans de grande taille ou nombreux,
+ce n'est pas difficile de placer cette fenêtre près de celle de Thonny,
+mais au lancement suivant, le gestionnaire de fenêtre peut la replacer n'importe où et il faut
+remettre en place à nouveau les fenêtres.
+
+**Ancrer les fenêtres utilisateur** dans le **menu Lancer** est prévu pour vous aider dans cette situation. Si vous
+cochez cette option et que vous lancez votre programme Tkinter, Thonny réaliser la magie suivante :
+
+* Il se souvient des emplacements de vos fenêtres. Les fois suivantes il place les fenêtres à la même position.
+* Il fait en sorte que votre fenêtre reste au-dessus même si on clique sur la fenêtre Thonny pour commencer à modifier le code. En fait, après que la fenêtre Tkinter est apparue, Thonny met automatiquement le focus sur sa propre fenêtre si bien que vous pouvez continuer à éditer le code sans utiliser la souris. Quand on a fini, il suffit d'appuyer à nouveau sur F5 et l'ancienne fenêtre est remplacée par la nouvelle.
+ 
+ 

--- a/thonny/plugins/help/fr_FR/errors.rst
+++ b/thonny/plugins/help/fr_FR/errors.rst
@@ -1,0 +1,51 @@
+`Accueil <index.rst>`_
+
+Comprendre les erreurs
+======================
+
+Si votre programme provoque des erreurs ou des résultats inadéquats ne tentez pas de réparer quoi que ce soit avant d'avoir compris
+le problème. On peut en lire plus dans  `une autre page <debugging.rst>`__,
+ici vous ne trouverez qu'un rapide revue pour faciliter la mise en place des idées.
+
+
+Êtes-vous effaré ?
+------------------
+
+Il ne faut pas ! Les messages d'erreur sont faits pour aider. Si vous recevez un message d'erreur, ça ne veut pas dire que vous êtes mauvais.
+Et non, vous n'avez pas cassé l'ordinateur. Bien que les messages d'erreur puissent ressembler à un sac de
+nœuds à première vue, avec de la pratique il est possible d'en tirer des informations utiles.
+
+
+À quel emplacement du code a eu lieu l'erreur ?
+-----------------------------------------------
+
+Les messages d'erreur dans Thonny ont des liens
+qui vous amènent à l'emplacement du code qui a causé l'erreur. Dans le cas de plusieurs liens, le dernier
+est généralement le plus pertinent.
+
+Si l'erreur est arrivée dans une fonction, alors le message a plusieurs liens.
+Essayez de cliquer sur ceux-ci un par une, du haut vers le bas, et vous verrez comment Python est arrivé à l'emplacement
+de l'erreur. Un tel ensemble de liens se nomme *la trace de la pile*.
+
+
+Que signifie l'erreur ?
+-----------------------
+
+La dernière ligne du bloc d'erreur dit quel a été le problème pour Python.
+Quand vous essayez de comprendre le message, n'oubliez pas le contexte et essayez d'associer
+certaines parties du message avec l'emplacement lié dans le code. De temps en temps l'Assistant de Thonny peut expliquer
+l'erreur en termes plus simples, et parfois il faut effectuer une recherche sur Internet pour ce message
+(n'oubliez pas d'ajouter le mot-clé "Python" pour la recherche).
+
+
+Qu'y avait-il dans les variables au moment de l'erreur ?
+--------------------------------------------------------
+
+Ouvrez la vue des variables et voyez
+par vous-même ! Si l'erreur s'est produite dans une fonction on peut voir les variables locales en cliquant les
+liens dans la trace de la pile.
+
+
+Comment le programme est-il arrivé dans cet état ?
+--------------------------------------------------
+Voir `la page au sujet du débogage <debugging.rst>`_ or `la page au sujet de l'utilisation des débogueurs de Thonny <debuggers.rst>`_.

--- a/thonny/plugins/help/fr_FR/flask.rst
+++ b/thonny/plugins/help/fr_FR/flask.rst
@@ -1,0 +1,37 @@
+`Accueil <index.rst>`_
+
+Développement Web avec Flask
+============================
+
+`Flask <http://flask.pocoo.org/>`__ est une infrastructure populaire pour créer des applications web avec Python.
+
+Les tutoriels Flask indiquent de lancer les programmes Flask en tapant certaines commandes dans un Terminal,
+mais ça peut intimider certains débutants. Thonny essaie de rendre les choses plus faciles et permet de lancer les programmes Flask
+comme n'importe quel autre programme (avec un simple F5). S'il détecte que vous lancez un programme Flask, il le lance
+avec quelques lignes de code en plus, qui démarrent le serveur de développement avec les réglages qui vont bien.
+
+
+Détails
+-------
+
+Thonny lancera le serveur de développement approximativement comme ceci :
+
+.. code::
+
+	os.environ["FLASK_ENV"] = "development"
+	app.run(threaded=False, use_reloader=False, debug=False)
+
+``threaded=False`` est utilisé car le débogueur de Thonny ne supporte que les programmes à un seul fil (thread),
+``use_reloader=False`` est utilisé car
+`le rechargement automatique n'est pas fiable quand Flask est lancé ainsi <http://flask.pocoo.org/docs/1.0/api/#flask.Flask.run>`_
+et ``debug=False`` est utilisé car cela semble causer moins d'erreurs "Address already in use".
+
+Si vous voulez un plus grand contrôle sur les réglages, alors il vous faut lancer la méthode ``run`` par vous-même, comme ceci, par exemple :
+
+.. code::
+
+	...
+	if __name__ == "__main__":
+		app.run(port=5005, threaded=False, use_reloader=True, debug=True)
+
+Dans ce cas Thonny n'ajoutera rien à votre code.

--- a/thonny/plugins/help/fr_FR/index.rst
+++ b/thonny/plugins/help/fr_FR/index.rst
@@ -1,0 +1,25 @@
+Sujets spécifiques
+==================
+
+* `Utilisation des débogueurs <debuggers.rst>`_
+* `Utilisation des paquets de tierces parties <packages.rst>`_
+* `Ancrer les fenêtres utilisateurs <dock.rst>`_
+* `Support spécial pour les programmes Turtle <turtle.rst>`_
+* `Spécifier des arguments de programme <program_arguments.rst>`_
+* `Mode simple et mode expert <modes.rst>`_
+* `Le Shell <shell.rst>`_
+* `Le Grapheur <plotter.rst>`_
+* `L'Œil d'oiseau (Birdseye) <birdseye.rst>`_
+* `Le développement web avec Flask <flask.rst>`_
+
+Sujets généraux
+===============
+
+* `Gérer les erreurs <errors.rst>`_
+* `Conseils généraux pour le débogage <debugging.rst>`_
+
+En Ligne
+========
+
+Vous trouverez plus d'information sur le wiki de Thonny :  https://github.com/thonny/thonny/wiki.
+

--- a/thonny/plugins/help/fr_FR/modes.rst
+++ b/thonny/plugins/help/fr_FR/modes.rst
@@ -1,0 +1,30 @@
+`Accueil <index.rst>`_
+
+Différents modes
+================
+*Outils → Options → Général* permet de régler l'interface utilisateur de Thonny selon un des trois modes différents.
+
+
+Mode ordinaire
+--------------
+
+C'est le mode par défaut. Il n'y a pas grand-chose à en dire.
+
+
+Mode simple
+-----------
+
+Dans ce mode les menus sont cachés et la vue des Variables est automatiquement ouverte.
+On peut utiliser un petit lien dans le coin en haut à droite pour revenir au mode ordinaire.
+
+
+Mode expert
+-----------
+
+Ce mode ressemble beaucoup au mode ordinaire, mais offre quelques fonctionnalités de plus, utiles pour enseigner.
+
+* Le menu Afficher dispose d'un item *Plein écran* pour mettre Thonny en mode plein écran.
+* Quand on double-clique sur l'onglet d'un éditeur ou d'une vue, cela permet de la maximiser ; on peut revenir à la taille d'origine en double-cliquant l'onglet à nouveau.
+* Le menu des Outils gagne un item de plus *Ouvrir et rejouer ...* qui permet de rejouer les journaux d'action de l'utilisateur.
+
+

--- a/thonny/plugins/help/fr_FR/packages.rst
+++ b/thonny/plugins/help/fr_FR/packages.rst
@@ -1,0 +1,52 @@
+`Accueil <index.rst>`_
+
+Installation de paquets de tierces parties
+==========================================
+
+Thonny a deux options pour l'installation de paquets de tierces parties.
+
+
+Avec pip dans l'interface graphique
+-----------------------------------
+
+Depuis le menu « Outils », sélectionnez « Gérer les paquets ... » et suivez les instructions.
+
+Avec pip en ligne de commande
+-----------------------------
+
+#. Depuis le menu « Outils », sélectionnez « Ouvrir un Shell système ... ». Vous devriez avoir un nouveau terminal, qui présente le nom correct de la commande *pip (normalement ``pip`` ou ``pip3``). Par la suite on supposera que le nom de la commande est ``pip``.
+#. Entrez ``pip install <package name>`` (p. ex. ``pip install pygame``) et tapez Entrée. Vous devriez voir *pip* qui télécharge et installe le paquet puis affiche son message de succès.
+#. Fermez le terminal (facultatif)
+#. Revenez à Thonny
+#. Réinitialisez l'interpréteur en sélectionnant « Arrêter/relancer » depuis le menu « Lancer » (ceci est nécessaire la première fois que vous faite l'installation pip)
+#. Commencez à utiliser la paquet.
+
+
+Utiliser des paquets Python scientifiques
+=========================================
+
+La distribution Python qui vient avec Thonny ne contient pas de bibliothèques de programmation scientifique
+(p. ex. `NumPy <http://numpy.org/>`_  et `Matplotlib <http://matplotlib.org/>`_). 
+
+Les versions récentes de la plupart des paquets Python scientifiques (p. ex. numpy, pandas et
+matplotlib) sont outillés pour les plate-formes populaires si bien que vous pouvez la plupart du temps les installer
+avec pip mais au cas où il y a des problèmes, vous pouvez utiliser Thonny avec une distribution
+Python séparée prévue pour le calcul scientifique
+(p. ex. `Anaconda <https://www.continuum.io/downloads>`_, `Canopy <https://www.enthought.com/products/canopy/>`_ 
+ou `Pyzo <http://www.pyzo.org/>`_).
+
+
+Exemple: Utilisation d'Anaconda
+-------------------------------
+
+Allez à https://www.continuum.io/downloads et téléchargez une distribution binaire appropriée pour
+votre plate-forme. La plupart du temps vous voudrez un installeur graphique et une version 64-bits (on peut avoir besoin
+d'une version 32-bits avec un très vieux système). **Notez que Thonny ne supporte que Python3, assurez-vous bien de choisir la version pour Python 3 d'Ananconda**.
+
+Installez-la et trouvez où il installe l'exécutable Python (*pythonw.exe* sous Windows et 
+*python3* ou *python* sous Linux et Mac).
+
+Dans Thonny ouvrez « Outils » et sélectionnez « Options ... ». Dans le dialogue d'options ouvrez l'onglet « Interpréteur »,
+cliquez « Sélectionner l'exécutable » et désignez l'emplacement de l'exécutable Python d'Anaconda.
+
+Après avoir fait ça, la prochaine fois que vous relancerez votre programme, il utilisera le Python d'Anaconda et toutes les bibliothèques installées là sont disponibles.

--- a/thonny/plugins/help/fr_FR/plotter.rst
+++ b/thonny/plugins/help/fr_FR/plotter.rst
@@ -1,0 +1,61 @@
+`Accueil <index.rst>`_
+
+Le grapheur
+===========
+
+Le grapheur est un greffon pour le Shell, qui en extrait les nombres venus
+du programme et les affiche comme une courbe. Il peut être utile pour
+observer des données de capteurs en direct venant de périphériques ou même pour analyser
+des données statiques (si vous hésitez à utiliser des outils plus sérieux). Il est inspiré
+du `Mu Python editor <https://codewith.mu/>`__. 
+
+Vous pouvez l'ouvrir depuis le menu « Afficher » ou depuis le menu contextuel du Shell.
+
+Par exemple essayez le programme suivant (on peut l'arrêter avec Ctrl+C ou
+avec le bouton Arrêter/Relancer de la barre d'outils) :
+
+.. code::
+
+	from time import sleep
+	from random import randint
+	
+	p1 = 0
+	while True:
+	    p1 += randint(-1, 1)
+	    p2 = randint(-10, 10)
+	    print("Marche aléatoire :", p1, " juste aléatoire:", p2)
+	    sleep(0.05)
+
+
+Quand on le lance avec le Grapheur ouvert, on voir un graphique en ligne avec deux courbes qui défilent.
+Chaque colonne du graphique correspond à une ligne dans le Shell.
+La colonne le plus à droite dans le graphique correspond toujours à la ligne visible en bas du Shell,
+même quand on arrête le programme et qu'on se déplace dans le texte du Shell.
+
+Le grapheur commence à tracer des courbes dès qu'il détecte au moins deux lignes consécutives contenant le même motif
+de nombres et de texte d'accompagnement. Les nombres sont représentés sous forme de courbes et le texte d'accompagnement
+devient la légende dans le coin en bas à droite du Grapheur.
+
+
+La vitesse de l'animation
+-------------------------
+
+À moins que vous ne produisiez un nombre fixe de lignes, c'est une bonne idée d'éviter de noyer
+le Shell et le Grapheur sous les données. C'est pourquoi l'exemple ci-dessus
+fait une petite pause (``sleep(0.05)``) avant d'afficher la ligne suivante.
+
+
+Intervalle de l'axe-Y
+---------------------
+
+Le Grapheur tente de détecter un intervalle adapté pour votre courbe sans qu'il soit
+nécessaire de le changer trop souvent. Pour cette raison, il augmente l'intervalle si besoin est, mais ne
+le diminue qu'au début d'une nouvelle série.
+
+Si certaines données extraordinaires rendent l'intervalle trop grand, on peut le rétrécir manuellement
+en attendant que les données trop grande sortent de la figure et en cliquant sur le Grapheur.
+
+Si vous voulez rendre l'intervalle plus grand (ou juste comparer vos valeurs à d'autres),
+il suffit simplement d'inclure une ou des constantes adéquates dans vos lignes de données, p.ex. :
+
+``print(0, measure1, measure2, 100)``.

--- a/thonny/plugins/help/fr_FR/program_arguments.rst
+++ b/thonny/plugins/help/fr_FR/program_arguments.rst
@@ -1,0 +1,28 @@
+`Accueil <index.rst>`_
+
+Lancer les programmes avec des arguments en ligne de commande
+=============================================================
+
+Quand nous éditez *mon_programme.py* et pressez la touche F5, Thonny construit une commande magique
+``%Run mon_program.py`` et l'envoie au shell, qui demande à la tâche de fond de Thonny de lancer ce script.
+
+Quand on utilise le shell et qu'on récupère la commande ``%Run`` (avec la flèche vers le haut), on peut y ajouter
+*des arguments en ligne de commande*. Par exemple on peut remplacer cette commande par
+``%Run mon_programme.py argument1 argument2`` et appuyer sur Entrée.
+
+Quand on lance le programme ainsi, il est possible d'accéder aux arguments à l'aide de ``sys.argv``:
+
+.. code::
+
+    import sys
+    print(sys.argv)
+
+Modifier les arguments en ligne de commande
+-------------------------------------------
+
+S'il faut utiliser le même ensemble d'arguments plusieurs fois, ça peut devenir ennuyeux de reconstruire
+le ``%Run`` à la main. Dans ce cas, vous pouvez cocher **Arguments du programme** dans le **menu Afficher**. Cela
+ouvre un petit champ de saisie près des boutons de la barre d'outils. Ensuite, tout ce qu'on tape dans cette
+zone de saisie est ajouté au bout du ``%Run <nom du script>`` à chaque fois qu'on presse la touche F5.
+
+ 	

--- a/thonny/plugins/help/fr_FR/shell.rst
+++ b/thonny/plugins/help/fr_FR/shell.rst
@@ -1,0 +1,97 @@
+`Accueil <index.rst>`_
+
+Le Shell
+========
+
+Le Shell est le moyen principal pour lancer et communiquer avec votre programme. Il ressemble pour l'essentiel à
+la boucle REPL (Read-Evaluate-Print Loop) officielle de Python, mais il y a quelques différences et propriétés supplémentaires.
+
+
+Les commandes Python
+--------------------
+
+Tout comme l'invite REPL officielle de Python, le Shell de Thonny accepte des expressions et des commandes Python, qu'elles soient
+sur une seule ligne ou sur plusieurs. Si on presse la touche Entrée, Thonny utilise quelques heuristiques pour prédire
+si on veut lancer la commande ou continuer à taper la commande sur la ligne suivante.
+Si vous voulez lancer la commande mais que Thonny vous offre une nouvelle ligne, vérifiez si vous avez oublié
+de refermer quelques parenthèses.
+
+
+Les commandes magiques
+----------------------
+
+Si on sélectionne "Lancer => Lancer le script courant" ou qu'on presse la touche F5, on voit que Thonny insère une commande
+commençant par ``%Run`` dans le Shell. Les commandes qui commencent par ``%`` sont appelées *commandes magiques* (tout
+comme dans `IPython <https://ipython.org/>`_ et elles réalisent certaines actionnes, qui ne peuvent pas
+(facilement) s'exprimer par des commandes Python. Les commandes magiques de Thonny ont d'habitude
+des commandes correspondantes dans le menu si bien qu'il est inutile de les écrire à la main.
+
+Les commandes système
+---------------------
+
+Si on doit rapidement lancer une simple commande système il n'est pas nécessaire de démarrer un Terminal. Il suffit de
+préfixer la commande par ``!`` (p. ex. ``!pytest mon-script.py``) et de la saisir dans le Shell de Thonny.
+
+
+L'historique des commandes
+--------------------------
+
+Si on veut relancer la même commande ou presque plusieurs fois, il n'est pas nécessaire de la retaper à chaque fois --
+on utilisera la flèche vers le haut pour récupérer la commande précédente dans l'historique. Une nouvelle action sur la même touche récupère le commande
+précédente et ainsi de suite. On utilise la touche flèche vers le bas pour se déplacer dans l'historique en sens opposé.
+
+
+Sortie colorisée
+----------------
+
+Si votre Shell est en mode émulation de Terminal (voir Outils => Options => Shell), on peut
+utiliser des `codes ANSI <https://en.wikipedia.org/wiki/ANSI_escape_code>`_ pour produire une sortie colorisée.
+
+Essayez l'exemple suivant :
+
+.. code::
+
+	print("\033[31m" + "Red" + "\033[m")
+	print("\033[1;3;33;46m" + "Texte brillant et gras, italique, en jaune sur fond cyan" + "\033[m")
+
+Vous pouvez avoir envie d'utiliser un paquet comme `colorama <https://pypi.org/project/colorama/>`_ pour produire
+Les codes couleur.
+
+
+Réécrire par-dessus les lignes de sortie
+----------------------------------------
+
+Les bons émulateurs de terminal supportent des codes ANSI autorisant l'écriture à une position arbitraire sur l'écran
+du terminal. Le Shell de Thonny ne peut pas en faire autant, mais il supporte cependant quelques trucs et astuces.
+
+Essayez le programme suivant :
+
+.. code::
+
+	from time import sleep
+	
+	for i in range(100):
+	    print(i, "%", end="")
+	    sleep(0.05)
+	    print("\r", end="")
+	
+	print("Terminé !")
+
+Le truc est d'utiliser le caractère ``"\r"``, qui fait revenir le curseur de sortie au début de la ligne
+courante, si bien que les caractères suivants seront affichés en écrasant le texte précédent. Notez bien l'usage de ``print(..., end="")``
+pour éviter de créer une nouvelle ligne.
+
+Le cousin de ``"\r"`` est ``"\b"``, qui déplace le curseur de sortie à gauche d'un caractère.
+Cela ne fait rien s'il est déjà à la première position de la ligne.
+
+		
+Émettre un son
+--------------
+
+Quand le Shell est en mode émulation de terminal, on peut faire sonner (ou émettre un tintement) en sortant un caractère ``"\a"``.
+ 
+ 
+Mettre en graphique une série de nombres
+----------------------------------------
+
+On peut visualiser les séries de nombres envoyées vers le Shell à l'aide du `Grapheur <plotter.rst>`_.

--- a/thonny/plugins/help/fr_FR/turtle.rst
+++ b/thonny/plugins/help/fr_FR/turtle.rst
@@ -1,0 +1,9 @@
+`Accueil <index.rst>`_
+
+Support spécial pour les programmes Turtle
+==========================================
+
+Quand on développe des programmes avec le module ``turtle``, Thonny offre le support suivant :
+
+* On peut faire sans les appels de ``mainloop``, ``done`` ou ``exitonclick`` dans le script (Thonny s'occupera de garder la fenêtre Turtle interactive). Cela permet de créer des parts de son dessin à l'aide d'un script et de continuer à ajouter des propriétés à l'aide du shell. On peut aussi faire tout le dessin à partir du shell.
+* On peut `ancrer la fenêtre Turtle <dock.rst>`_, afin qu'elle reste bien visibles tant qu'on travaille sur le script.

--- a/thonny/workbench.py
+++ b/thonny/workbench.py
@@ -1229,13 +1229,13 @@ class Workbench(tk.Tk):
         )
         label.grid(row=0, column=1001, sticky="ne")
 
-        def on_click(_):
+        def on_click(ev):
             self.set_option("general.ui_mode", "regular")
             tk_messagebox.showinfo(
-                "Regular mode",
-                "Configuration has been updated. "
-                + "Restart Thonny to start working in regular mode.\n\n"
-                + "(See 'Tools → Options → General' if you change your mind later.)",
+                _("Regular mode",)
+                _("Configuration has been updated. ")
+                + _("Restart Thonny to start working in regular mode.\n\n")
+                + _("(See 'Tools → Options → General' if you change your mind later.)"),
                 parent=self,
             )
 

--- a/thonny/workbench.py
+++ b/thonny/workbench.py
@@ -480,7 +480,7 @@ class Workbench(tk.Tk):
         self.add_backend(
             "SameAsFrontend",
             running.SameAsFrontendCPythonProxy,
-            "The same interpreter which runs Thonny (default)",
+            _("The same interpreter which runs Thonny (default)"),
             running.get_frontend_python(),
             "1",
         )
@@ -499,8 +499,8 @@ class Workbench(tk.Tk):
             "PrivateVenv",
             running.PrivateVenvCPythonProxy,
             _("A special virtual environment (deprecated)"),
-            "This virtual environment is automatically maintained by Thonny.\n"
-            "Location: " + running.get_private_venv_path(),
+            _("This virtual environment is automatically maintained by Thonny.\n")
+            + _("Location: ") + running.get_private_venv_path(),
             "z",
         )
 
@@ -545,7 +545,7 @@ class Workbench(tk.Tk):
             else [],
         )
 
-        self.add_command("show_options", "tools", "Options...", self.show_options, group=180)
+        self.add_command("show_options", "tools", _("Options..."), self.show_options, group=180)
         self.createcommand("::tk::mac::ShowPreferences", self.show_options)
         self.createcommand("::tk::mac::Quit", self._mac_quit)
 
@@ -617,7 +617,7 @@ class Workbench(tk.Tk):
             self.add_command(
                 "font",
                 "tools",
-                "Change font size",
+                _("Change font size"),
                 caption="Zoom",
                 handler=self._toggle_font_size,
                 image="zoom",
@@ -627,7 +627,7 @@ class Workbench(tk.Tk):
             self.add_command(
                 "quit",
                 "help",
-                "Exit Thonny",
+                _("Exit Thonny"),
                 self._on_close,
                 image="quit",
                 caption="Quit",
@@ -1011,7 +1011,7 @@ class Workbench(tk.Tk):
         images: Dict[str, str] = {},
     ) -> None:
         if name in self._ui_themes:
-            warn("Overwriting theme '%s'" % name)
+            warn(_("Overwriting theme '%s'") % name)
 
         self._ui_themes[name] = (parent, settings, images)
 
@@ -1019,7 +1019,7 @@ class Workbench(tk.Tk):
         self, name: str, parent: Optional[str], settings: FlexibleSyntaxThemeSettings
     ) -> None:
         if name in self._syntax_themes:
-            warn("Overwriting theme '%s'" % name)
+            warn(_("Overwriting theme '%s'") % name)
 
         self._syntax_themes[name] = (parent, settings)
 
@@ -1046,7 +1046,7 @@ class Workbench(tk.Tk):
             else:
                 return result
         else:
-            raise NotImplementedError("Only numeric dimensions supported at the moment")
+            raise NotImplementedError(_("Only numeric dimensions supported at the moment"))
 
     def _register_ui_theme_as_tk_theme(self, name: str) -> None:
         # collect settings from all ancestors
@@ -1118,7 +1118,7 @@ class Workbench(tk.Tk):
             try:
                 parent, settings = self._syntax_themes[name]
             except KeyError:
-                self.report_exception("Can't find theme '%s'" % name)
+                self.report_exception(_("Can't find theme '%s'") % name)
                 return {}
 
             if callable(settings):
@@ -1178,7 +1178,7 @@ class Workbench(tk.Tk):
         col = 1000
         self._toolbar.columnconfigure(col, weight=1)
 
-        label = ttk.Label(frame, text="Program arguments:")
+        label = ttk.Label(frame, text=_("Program arguments:"))
         label.grid(row=0, column=0, sticky="nse", padx=5)
 
         self.program_arguments_box = ttk.Combobox(
@@ -1221,7 +1221,7 @@ class Workbench(tk.Tk):
 
         label = ttk.Label(
             self._toolbar,
-            text="Switch to\nregular mode",
+            text=_("Switch to\nregular mode"),
             justify="right",
             font="SmallLinkFont",
             style="Url.TLabel",
@@ -1231,8 +1231,8 @@ class Workbench(tk.Tk):
 
         def on_click(ev):
             self.set_option("general.ui_mode", "regular")
-            tk_messagebox.showinfo(
-                _("Regular mode",)
+            tk.messagebox.showinfo(
+                _("Regular mode"),
                 _("Configuration has been updated. ")
                 + _("Restart Thonny to start working in regular mode.\n\n")
                 + _("(See 'Tools → Options → General' if you change your mind later.)"),
@@ -1266,7 +1266,7 @@ class Workbench(tk.Tk):
                 try:
                     self.show_view(view_id, False)
                 except Exception:
-                    self.report_exception("Problem showing " + view_id)
+                    self.report_exception(_("Problem showing ") + view_id)
 
     def update_image_mapping(self, mapping: Dict[str, str]) -> None:
         """Was used by thonny-pi. Not recommended anymore"""
@@ -1328,7 +1328,7 @@ class Workbench(tk.Tk):
     def get_view(self, view_id: str, create: bool = True) -> tk.Widget:
         if "instance" not in self._view_records[view_id]:
             if not create:
-                raise RuntimeError("View %s not created" % view_id)
+                raise RuntimeError(_("View %s not created") % view_id)
             class_ = self._view_records[view_id]["class"]
             location = self._view_records[view_id]["location"]
             master = self._view_notebooks[location]
@@ -1488,7 +1488,7 @@ class Workbench(tk.Tk):
                     try:
                         handler(event)
                     except Exception:
-                        self.report_exception("Problem when handling '" + sequence + "'")
+                        self.report_exception(_("Problem when handling '") + sequence + "'")
 
         self._update_toolbar()
 
@@ -1656,7 +1656,7 @@ class Workbench(tk.Tk):
             if menu == self._menubar.winfo_children()[i]:
                 return i
 
-        raise RuntimeError("Couldn't find menu")
+        raise RuntimeError(_("Couldn't find menu"))
 
     def _add_toolbar_button(
         self,
@@ -1671,7 +1671,7 @@ class Workbench(tk.Tk):
     ) -> None:
 
         assert caption is not None and len(caption) > 0, (
-            "Missing caption for '%s'. Toolbar commands must have caption." % command_label
+            _("Missing caption for '%s'. Toolbar commands must have caption.") % command_label
         )
         slaves = self._toolbar.grid_slaves(0, toolbar_group)
         if len(slaves) == 0:


### PR DESCRIPTION
Hello, here is the translation of help pages to French.
Files `thonny/plugins/help/__init__.py` and `thonny/workbench.py` bear some modifications which are the same as in my other pull request, for consistency of the present pull request.

Thank you for considering this pull request shortly, as it does not *change* much parts in your master branch. Most of this pull is made of additions.

About the creation of a subdirectory en_US : please feel free to create one such directory. Language purists may suggest creating also us_GB, en_IE, en_IN, etc. However I do believe that default help files should still remain in the parent directory (if they were written and checked by a native speaker, then they can be copied into some en_FOO subdirectory right now).