### PR TITLE
Prevents internal error in Object Inspector

### DIFF
--- a/thonny/plugins/object_inspector.py
+++ b/thonny/plugins/object_inspector.py
@@ -74,9 +74,9 @@ class ObjectInspector(ttk.Frame):
                     page.grid(row=1, column=0, sticky="nsew", padx=0)
                     tab.configure(style="Active.ViewTab.TLabel")
                     if self.active_page == self.attributes_page and (
-                        self.object_info is None or
-                        "attributes" in self.object_info and
-                        self.object_info["attributes"] == {}
+                        self.object_info is None
+                        or "attributes" in self.object_info
+                        and self.object_info["attributes"] == {}
                     ):
                         self.request_object_info()
 

--- a/thonny/plugins/object_inspector.py
+++ b/thonny/plugins/object_inspector.py
@@ -74,7 +74,9 @@ class ObjectInspector(ttk.Frame):
                     page.grid(row=1, column=0, sticky="nsew", padx=0)
                     tab.configure(style="Active.ViewTab.TLabel")
                     if self.active_page == self.attributes_page and (
-                        self.object_info is None or self.object_info["attributes"] == {}
+                        self.object_info is None or
+                        "attributes" in self.object_info and
+                        self.object_info["attributes"] == {}
                     ):
                         self.request_object_info()
 


### PR DESCRIPTION
When switching between `Data` and `Atts` twice, the `object_info` dictionary would throw
an internal error because it didn't have the `attributes` key.