### PR TITLE
Force to de-assert DTR# and RTS# at Thonny startup

### DIFF
--- a/thonny/plugins/micropython/serial_connection.py
+++ b/thonny/plugins/micropython/serial_connection.py
@@ -15,6 +15,8 @@ class SerialConnection(MicroPythonConnection):
 
         try:
             self._serial = serial.Serial(port, baudrate=baudrate, timeout=None)
+            self._serial.dtr = 0
+            self._serial.rts = 0
         except SerialException as error:
             err_str = str(error)
             if "FileNotFoundError" in err_str:


### PR DESCRIPTION
Some Arduino-style boards that connect DTR# or RTS# to RESET directly.  And sometimes, the driver of the serial port asserts the DTR# and RTS# (Verifyied with CH340G and CP2102). So I suggest that we de-assert DTR# and RTS# at the plugin starting.