### PR TITLE
Add default black fg color to tooltips for macOS dark mode

### DIFF
--- a/thonny/ui_utils.py
+++ b/thonny/ui_utils.py
@@ -1147,6 +1147,7 @@ class ToolTip:
 def create_tooltip(widget, text, **kw):
     options = get_style_configuration("Tooltip").copy()
     options.setdefault("background", "#ffffe0")
+    options.setdefault("foreground", "#000000")
     options.setdefault("relief", "solid")
     options.setdefault("borderwidth", 1)
     options.setdefault("padx", 1)


### PR DESCRIPTION
On macOS in the dark mode, the tooltips are white text on a yellowish background, rendering them unreadable. This adds the default foreground color set to black.