### PR TITLE
Hide underscored names from autocomplete suggestions unless user already typed '_'

### DIFF
--- a/thonny/plugins/autocomplete.py
+++ b/thonny/plugins/autocomplete.py
@@ -71,10 +71,10 @@ class Completer(tk.Listbox):
             self._present_completions(msg.completions)
 
     def _present_completions(self, completions_):
-        if get_workbench().get_option('edit.tab_complete_show_private'):
-          completions = completions_
+        if get_workbench().get_option("edit.tab_complete_show_private"):
+            completions = completions_
         else:
-          completions = [c for c in completions_ if not c.get('name', '_').startswith('_')]
+            completions = [c for c in completions_ if not c.get("name", "_").startswith("_")]
 
         self.completions = completions
 

--- a/thonny/plugins/autocomplete.py
+++ b/thonny/plugins/autocomplete.py
@@ -77,10 +77,10 @@ class Completer(tk.Listbox):
         # if it doesn't - don't show names starting with '_'
         source = self.text.get("1.0", "end-1c")
         try:
-            last_source_chunk = re.split(r'\.|\s', source)[-1]
+            last_source_chunk = re.split(r"\.|\s", source)[-1]
         except IndexError:
-            last_source_chunk = ''
-        complete_underscored = last_source_chunk.startswith('_')
+            last_source_chunk = ""
+        complete_underscored = last_source_chunk.startswith("_")
 
         if complete_underscored:
             completions = completions_

--- a/thonny/plugins/autocomplete.py
+++ b/thonny/plugins/autocomplete.py
@@ -70,7 +70,12 @@ class Completer(tk.Listbox):
         else:
             self._present_completions(msg.completions)
 
-    def _present_completions(self, completions):
+    def _present_completions(self, completions_):
+        if get_workbench().get_option('edit.tab_complete_show_private'):
+          completions = completions_
+        else:
+          completions = [c for c in completions_ if not c.get('name', '_').startswith('_')]
+
         self.completions = completions
 
         # broadcast logging info
@@ -323,6 +328,7 @@ def load_plugin() -> None:
 
     get_workbench().set_default("edit.tab_complete_in_editor", True)
     get_workbench().set_default("edit.tab_complete_in_shell", True)
+    get_workbench().set_default("edit.tab_complete_show_private", True)
 
     CodeViewText.perform_midline_tab = patched_perform_midline_tab  # type: ignore
     ShellText.perform_midline_tab = patched_perform_midline_tab  # type: ignore

--- a/thonny/plugins/autocomplete.py
+++ b/thonny/plugins/autocomplete.py
@@ -75,14 +75,13 @@ class Completer(tk.Listbox):
     def _present_completions(self, completions_):
         # Check if autocompeted name starts with an underscore,
         # if it doesn't - don't show names starting with '_'
-        source = self.text.get("1.0", "end-1c")
+        source = self.text.get("insert linestart", tk.INSERT)
         try:
-            last_source_chunk = re.split(r"\.|\s", source)[-1]
+            current_source_chunk = re.split(r"\W", source)[-1]
         except IndexError:
-            last_source_chunk = ""
-        complete_underscored = last_source_chunk.startswith("_")
+            current_source_chunk = ""
 
-        if complete_underscored:
+        if current_source_chunk.startswith("_"):
             completions = completions_
         else:
             completions = [c for c in completions_ if not c.get("name", "_").startswith("_")]

--- a/thonny/plugins/autocomplete.py
+++ b/thonny/plugins/autocomplete.py
@@ -1,3 +1,5 @@
+import re
+
 import tkinter as tk
 from tkinter import messagebox
 
@@ -71,7 +73,16 @@ class Completer(tk.Listbox):
             self._present_completions(msg.completions)
 
     def _present_completions(self, completions_):
-        if get_workbench().get_option("edit.tab_complete_show_private"):
+        # Check if autocompeted name starts with an underscore,
+        # if it doesn't - don't show names starting with '_'
+        source = self.text.get("1.0", "end-1c")
+        try:
+            last_source_chunk = re.split(r'\.|\s', source)[-1]
+        except IndexError:
+            last_source_chunk = ''
+        complete_underscored = last_source_chunk.startswith('_')
+
+        if complete_underscored:
             completions = completions_
         else:
             completions = [c for c in completions_ if not c.get("name", "_").startswith("_")]
@@ -328,7 +339,6 @@ def load_plugin() -> None:
 
     get_workbench().set_default("edit.tab_complete_in_editor", True)
     get_workbench().set_default("edit.tab_complete_in_shell", True)
-    get_workbench().set_default("edit.tab_complete_show_private", True)
 
     CodeViewText.perform_midline_tab = patched_perform_midline_tab  # type: ignore
     ShellText.perform_midline_tab = patched_perform_midline_tab  # type: ignore

--- a/thonny/plugins/editor_config_page.py
+++ b/thonny/plugins/editor_config_page.py
@@ -47,7 +47,6 @@ class EditorConfigurationPage(ConfigurationPage):
             columnspan=2,
         )
 
-
         self.add_checkbox("view.show_line_numbers", tr("Show line numbers"), pady=(20, 0))
         self._line_length_var = get_workbench().get_variable("view.recommended_line_length")
         label = ttk.Label(

--- a/thonny/plugins/editor_config_page.py
+++ b/thonny/plugins/editor_config_page.py
@@ -41,6 +41,12 @@ class EditorConfigurationPage(ConfigurationPage):
             tr("Allow code completion with Tab-key in Shell"),
             columnspan=2,
         )
+        self.add_checkbox(
+            "edit.tab_complete_show_private",
+            tr("Allow names starting with '_' char in completions"),
+            columnspan=2,
+        )
+
 
         self.add_checkbox("view.show_line_numbers", tr("Show line numbers"), pady=(20, 0))
         self._line_length_var = get_workbench().get_variable("view.recommended_line_length")

--- a/thonny/plugins/editor_config_page.py
+++ b/thonny/plugins/editor_config_page.py
@@ -41,11 +41,6 @@ class EditorConfigurationPage(ConfigurationPage):
             tr("Allow code completion with Tab-key in Shell"),
             columnspan=2,
         )
-        self.add_checkbox(
-            "edit.tab_complete_show_private",
-            tr("Allow names starting with '_' char in completions"),
-            columnspan=2,
-        )
 
         self.add_checkbox("view.show_line_numbers", tr("Show line numbers"), pady=(20, 0))
         self._line_length_var = get_workbench().get_variable("view.recommended_line_length")


### PR DESCRIPTION
@aivarannamaa 

Hi, I would like to discuss a feature that would allow names that start with underscore character not to be on the autocompletion list.

I've added the option "Allow names starting with '_' char in completions" which is set to `True` by default. The reasoning behind this option is that in Python, private names begin with this character. Those private names add clutter especially for beginners who wouldn't need to use them (at least in the project I'm working on now).

As for now, this is just a draft. I'd like to be able to force the completion if at least one underscore has already been typed by the user. Another option for solving the issue is just to move the underscored completions to the end of the list. I'd like to know your opinion on that.

Regards,
Aleksander