### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/thonny/base_file_browser.py
+++ b/thonny/base_file_browser.py
@@ -906,7 +906,6 @@ class BaseLocalFileBrowser(BaseFileBrowser):
         if event["operation"] in ["save", "delete"]:
             self.refresh_tree()
             self.select_path_if_visible(event["path"])
-            # TODO: select this file in tree?
 
     def request_fs_info(self, path):
         if path == "":


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
thonny/base_file_browser.py (line:909)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: https://github.com/thonny/thonny/commit/2ef4d21da1f862f4e1ea464de05f8992bd61e09f