### PR TITLE
Fixing the print margin for numbers

### DIFF
--- a/thonny/plugins/printing/template.html
+++ b/thonny/plugins/printing/template.html
@@ -33,7 +33,7 @@ code:before {
     border-right: solid gray 1px;
     display: inline-block;
     text-align: right;
-    min-width: 2em;
+    min-width: 3em;
     font-style: italic;
     -webkit-user-select: none;
 }

--- a/thonny/plugins/printing/template.html
+++ b/thonny/plugins/printing/template.html
@@ -33,7 +33,7 @@ code:before {
     border-right: solid gray 1px;
     display: inline-block;
     text-align: right;
-    width: 2em;
+    min-width: 2em;
     font-style: italic;
     -webkit-user-select: none;
 }


### PR DESCRIPTION
The earlier version had a fixed margin of 2em. Switching to a minimum of 2em- this should scale to accommodate longer text for numbers beyond 1000. Fixes #1646 