### PR TITLE
Hide extra dependencies in plugin manager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ docutils>=0.14
 mypy>=0.670
 asttokens>=1.1
 Send2Trash>=1.4
-packaging>=20.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ docutils>=0.14
 mypy>=0.670
 asttokens>=1.1
 Send2Trash>=1.4
+packaging>=20.9

--- a/thonny/test/plugins/test_pip_gui.py
+++ b/thonny/test/plugins/test_pip_gui.py
@@ -1,0 +1,15 @@
+from thonny.plugins.pip_gui import _EXTRA_MARKER_RE
+
+
+def test_extra_marker_re() -> None:
+    for text in [
+        "extra == 'dev'",
+        r"extra == 'dev \' with quote'",
+        "  extra  ==  'dev'  ",
+        'extra == "dev"',
+        r'extra == "dev \"with quote"',
+    ]:
+        assert _EXTRA_MARKER_RE.match(text) is not None
+
+    for text in ["extra == 'dev' and extra == 'dev1'", "extra == 'dev' or extra == 'dev1'"]:
+        assert _EXTRA_MARKER_RE.match(text) is None


### PR DESCRIPTION
This patch hides the dependencies of a plug-in which refer to
`extra == *`.

These dependencies can be confusing for the user as they are actually
not installed. For example, a plug-in might use `black` to format the
code and mark it as `dev` dependency, but Thonny will not install it
when acquiring the plug-in.

We added `packaging` to requirements instead of importing
`packaging.markers` from `pkg_resources` or `pip` (as library). This is
much easier to trace instead of using `__import__` builtin.

Fixes #1709.