### PR TITLE
recognize method and function calls for syntax coloring

### DIFF
--- a/thonny/plugins/coloring.py
+++ b/thonny/plugins/coloring.py
@@ -99,6 +99,8 @@ class SyntaxColorer:
             "definition",
             "function_call",
             "method_call",
+            "class_definition",
+            "function_definition",
         }
         self.multiline_tags = {"string3", "open_string3"}
         self._raise_tags()
@@ -112,7 +114,7 @@ class SyntaxColorer:
         self.text.tag_raise("open_string3")
         self.text.tag_raise("open_string")
         self.text.tag_raise("sel")
-        self.text.tag_raise("builtin")
+        self.text.tag_raise("builtin", "function_call")
         """
         tags = self.text.tag_names()
         # take into account that without themes some tags may be undefined
@@ -190,6 +192,15 @@ class SyntaxColorer:
                                 id_match_start, id_match_end = id_match.span(1)
                                 self.text.tag_add(
                                     "definition",
+                                    start + "+%dc" % id_match_start,
+                                    start + "+%dc" % id_match_end,
+                                )
+                                if token_text == "def":
+                                    tag_type = "function_definition"
+                                else:
+                                    tag_type = "class_definition"
+                                self.text.tag_add(
+                                    tag_type,
                                     start + "+%dc" % id_match_start,
                                     start + "+%dc" % id_match_end,
                                 )

--- a/thonny/plugins/coloring.py
+++ b/thonny/plugins/coloring.py
@@ -50,6 +50,8 @@ class SyntaxColorer:
             STRING_CLOSED,
             STRING_OPEN,
             TAB,
+            FUNCTIONS,
+            METHODS,
         )
 
         self.uniline_regex = re.compile(
@@ -69,7 +71,11 @@ class SyntaxColorer:
             + "|"
             + STRING_OPEN
             + "|"
-            + TAB,
+            + TAB
+            + "|"
+            + FUNCTIONS
+            + "|"
+            + METHODS,
             re.S,  # @UndefinedVariable
         )
 
@@ -91,6 +97,8 @@ class SyntaxColorer:
             "number",
             "builtin",
             "definition",
+            "functions",
+            "methods",
         }
         self.multiline_tags = {"string3", "open_string3"}
         self._raise_tags()

--- a/thonny/plugins/coloring.py
+++ b/thonny/plugins/coloring.py
@@ -50,8 +50,8 @@ class SyntaxColorer:
             STRING_CLOSED,
             STRING_OPEN,
             TAB,
-            FUNCTIONS,
-            METHODS,
+            FUNCTION_CALL,
+            METHOD_CALL,
         )
 
         self.uniline_regex = re.compile(
@@ -73,9 +73,9 @@ class SyntaxColorer:
             + "|"
             + TAB
             + "|"
-            + FUNCTIONS
+            + FUNCTION_CALL
             + "|"
-            + METHODS,
+            + METHOD_CALL,
             re.S,  # @UndefinedVariable
         )
 
@@ -97,8 +97,8 @@ class SyntaxColorer:
             "number",
             "builtin",
             "definition",
-            "functions",
-            "methods",
+            "function_call",
+            "method_call",
         }
         self.multiline_tags = {"string3", "open_string3"}
         self._raise_tags()

--- a/thonny/plugins/coloring.py
+++ b/thonny/plugins/coloring.py
@@ -112,6 +112,7 @@ class SyntaxColorer:
         self.text.tag_raise("open_string3")
         self.text.tag_raise("open_string")
         self.text.tag_raise("sel")
+        self.text.tag_raise("builtin")
         """
         tags = self.text.tag_names()
         # take into account that without themes some tags may be undefined

--- a/thonny/token_utils.py
+++ b/thonny/token_utils.py
@@ -30,6 +30,9 @@ NUMBER = matches_any(
 )
 # TODO: would it make regex too slow? VARIABLE = matches_any("VARIABLE", [...])
 
+METHODS = matches_any('methods', [r"(?<=\.)([a-zA-Z_]+)(?=\()"])
+FUNCTIONS = matches_any('functions', [r"(?<=[^.a-zA-Z_])([a-zA-Z_]+)(?=\()"])
+
 COMMENT = matches_any("comment", [r"#[^\n]*"])
 MAGIC_COMMAND = matches_any("magic", [r"^%[^\n]*"])  # used only in shell
 STRINGPREFIX = r"(\br|u|ur|R|U|UR|Ur|uR|b|B|br|Br|bR|BR|rb|rB|Rb|RB|f|F|fr|Fr|fR|FR|rf|rF|Rf|RF)?"

--- a/thonny/token_utils.py
+++ b/thonny/token_utils.py
@@ -30,8 +30,8 @@ NUMBER = matches_any(
 )
 # TODO: would it make regex too slow? VARIABLE = matches_any("VARIABLE", [...])
 
-METHODS = matches_any("methods", [r"(?<=\.)([a-zA-Z_]+)(?=\()"])
-FUNCTIONS = matches_any("functions", [r"(?<=[^.a-zA-Z_])([a-zA-Z_]+)(?=\()"])
+METHOD_CALL = matches_any("method_call", [r"(?<=\.)([\w_]+)(?=\()"])
+FUNCTION_CALL = matches_any("function_call", [r"(?<=[^._\w])([\w_]+)(?=\()"])
 
 COMMENT = matches_any("comment", [r"#[^\n]*"])
 MAGIC_COMMAND = matches_any("magic", [r"^%[^\n]*"])  # used only in shell

--- a/thonny/token_utils.py
+++ b/thonny/token_utils.py
@@ -31,7 +31,7 @@ NUMBER = matches_any(
 # TODO: would it make regex too slow? VARIABLE = matches_any("VARIABLE", [...])
 
 METHOD_CALL = matches_any("method_call", [r"(?<=\.)([\w_]+)(?=\()"])
-FUNCTION_CALL = matches_any("function_call", [r"(?<=[^._\w])([\w_]+)(?=\()"])
+FUNCTION_CALL = matches_any("function_call", [r"(?:(?<=^)|(?<=[^._\w]))([\w_]+)(?=\()"])
 
 COMMENT = matches_any("comment", [r"#[^\n]*"])
 MAGIC_COMMAND = matches_any("magic", [r"^%[^\n]*"])  # used only in shell

--- a/thonny/token_utils.py
+++ b/thonny/token_utils.py
@@ -30,8 +30,8 @@ NUMBER = matches_any(
 )
 # TODO: would it make regex too slow? VARIABLE = matches_any("VARIABLE", [...])
 
-METHODS = matches_any('methods', [r"(?<=\.)([a-zA-Z_]+)(?=\()"])
-FUNCTIONS = matches_any('functions', [r"(?<=[^.a-zA-Z_])([a-zA-Z_]+)(?=\()"])
+METHODS = matches_any("methods", [r"(?<=\.)([a-zA-Z_]+)(?=\()"])
+FUNCTIONS = matches_any("functions", [r"(?<=[^.a-zA-Z_])([a-zA-Z_]+)(?=\()"])
 
 COMMENT = matches_any("comment", [r"#[^\n]*"])
 MAGIC_COMMAND = matches_any("magic", [r"^%[^\n]*"])  # used only in shell


### PR DESCRIPTION
While working on my own theme for Thonny (porting a theme from jEdit), I noticed that there is no recognition for method or function calls as is the case in other editors. So I have added a regular expression to catch these. As to speed, I am not sure, but anecdotally I tried editing a large (5000+ lines) file and did not notice any issue.  With the regular expressions, I did not include optional spaces before opening parenthesis, I am not sure if that would be needed.

<img width="835" alt="Screen Shot 2021-07-03 at 3 06 43 PM" src="https://user-images.githubusercontent.com/174064/124364570-5777f980-dc10-11eb-82ab-faf516fcd281.png">
