### PR TITLE
Flatpak fixes

### DIFF
--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -1,5 +1,12 @@
 # Linux
 
+## Release
+
+On Linux, the AppData file, i.e. `org.thonny.Thonny.appdata.xml` for Thonny, contains information presented users in app stores.
+This includes information about each release.
+Thus, before cutting a release, it's important to add at least the version of the release and the date to the top of the `releases` section of the AppData file.
+It's also helpful to add a description of the changes the new release brings with it.
+
 ## Flatpak
 
 The instructions here describe how to build and update the development version of the Thonny Flatpak.

--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -5,6 +5,12 @@ runtime: org.freedesktop.Platform
 runtime-version: "20.08"
 sdk: org.freedesktop.Sdk
 command: thonny
+tags:
+  - devel
+  - development
+  - nightly
+# todo Better distinguish between the release and development installations by using a dedicated icon to represent the development Flatpak instead of prefixing the name.
+desktop-file-name-prefix: "(Development) "
 cleanup:
   - /man
   - /share/man

--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -13,6 +13,11 @@ finish-args:
   # Thonny requires access to serial / USB devices for embedded development.
   - --device=all
 
+  - --filesystem=xdg-config/Thonny
+  - --filesystem=~/.local/lib
+  - --filesystem=xdg-desktop
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-downloads
   - --filesystem=home
   - --share=ipc
   - --share=network

--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -13,11 +13,10 @@ finish-args:
   # Thonny requires access to serial / USB devices for embedded development.
   - --device=all
 
-  - --filesystem=xdg-config/Thonny
   - --filesystem=~/.local/lib
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
-  - --filesystem=xdg-downloads
+  - --filesystem=xdg-download
   - --filesystem=home
   - --share=ipc
   - --share=network

--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -13,14 +13,13 @@ finish-args:
   # Thonny requires access to serial / USB devices for embedded development.
   - --device=all
 
+  # Thonny stores Python plugins in subdirectories under ~/.local/lib corresponding to the Python / Thonny version.
   - --filesystem=~/.local/lib
-  - --filesystem=xdg-desktop
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=home
+
   - --share=ipc
   - --share=network
   - --socket=x11
+  - --talk-name=org.freedesktop.FileManager1
 modules:
   - name: tcl
     buildsystem: autotools

--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -17,7 +17,6 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
-  - --socket=wayland
 modules:
   - name: tcl
     buildsystem: autotools

--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -43,4 +43,10 @@
 
   <content_rating type="oars-1.1" />
 
+  <releases>
+    <release version="3.3.11" date="2021-06-25" />
+    <release version="3.3.10" date="2021-05-18" />
+    <release version="3.3.7" date="2021-04-30" />
+  </releases>
+
 </component>

--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -44,9 +44,27 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="3.3.11" date="2021-06-25" />
-    <release version="3.3.10" date="2021-05-18" />
-    <release version="3.3.7" date="2021-04-30" />
+    <release version="3.3.11" date="2021-06-25">
+      <description>
+        <p>
+          This is a bug-fix release.
+        </p>
+      </description>
+    </release>
+    <release version="3.3.10" date="2021-05-18">
+      <description>
+        <p>
+          This is mainly a bug-fix release with one new feature -- the ability to install pip-compatible packages for MicroPython.
+        </p>
+      </description>
+    </release>
+    <release version="3.3.7" date="2021-04-30">
+      <description>
+        <p>
+          This is mainly a bug-fix release.
+        </p>
+      </description>
+    </release>
   </releases>
 
 </component>

--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -41,4 +41,6 @@
     <binary>thonny</binary>
   </provides>
 
+  <content_rating type="oars-1.1" />
+
 </component>

--- a/thonny/misc_utils.py
+++ b/thonny/misc_utils.py
@@ -512,3 +512,9 @@ class PopenWithOutputQueues(subprocess.Popen):
             if data == "":
                 break
             target_queue.put(data)
+
+
+def inside_flatpak():
+    import shutil
+
+    return shutil.which("flatpak-spawn") and os.path.isfile("/app/manifest.json")

--- a/thonny/misc_utils.py
+++ b/thonny/misc_utils.py
@@ -518,3 +518,13 @@ def inside_flatpak():
     import shutil
 
     return shutil.which("flatpak-spawn") and os.path.isfile("/app/manifest.json")
+
+
+def show_command_not_available_in_flatpak_message():
+    from tkinter import messagebox
+    from thonny.languages import tr
+
+    messagebox.showinfo(
+        tr("Command not available"),
+        tr("This command is not available if Thonny is run via Flatpak"),
+    )

--- a/thonny/plugins/help/packages.rst
+++ b/thonny/plugins/help/packages.rst
@@ -15,6 +15,12 @@ With pip on command line
 #. Reset interpreter by selecting "Stop/Reset" from "Run menu" (this is required only first time you do pip install)
 #. Start using the package
 
+.. NOTE::
+   The "Open system shell..." menu is not available when running from the Flatpak on Linux.
+   Flatpak applications are sandboxed to protect the user's host system and data.
+   Allowing Thonny to open a shell on the host system would circumvent these protections.
+   To install Python packages from the command-line, please open your system's terminal application directly.
+
 
 Using scientific Python packages
 ================================

--- a/thonny/plugins/system_shell/__init__.py
+++ b/thonny/plugins/system_shell/__init__.py
@@ -52,12 +52,20 @@ def _open_system_shell():
     return terminal.run_in_terminal(cmd, cwd, env_overrides, True)
 
 
+def _inside_flatpak():
+    import os
+    import shutil
+
+    return shutil.which("flatpak-spawn") and os.path.isfile("/app/manifest.json")
+
+
 def load_plugin() -> None:
-    get_workbench().add_command(
-        "OpenSystemShell",
-        "tools",
-        tr("Open system shell..."),
-        _open_system_shell,
-        group=80,
-        image="terminal",
-    )
+    if not _inside_flatpak:
+        get_workbench().add_command(
+            "OpenSystemShell",
+            "tools",
+            tr("Open system shell..."),
+            _open_system_shell,
+            group=80,
+            image="terminal",
+        )

--- a/thonny/plugins/system_shell/__init__.py
+++ b/thonny/plugins/system_shell/__init__.py
@@ -7,6 +7,7 @@ from thonny import get_runner, get_workbench, terminal
 from thonny.common import get_augmented_system_path, get_exe_dirs
 from thonny.editors import get_saved_current_script_filename
 from thonny.languages import tr
+from thonny.misc_utils import inside_flatpak
 from thonny.running import get_environment_overrides_for_python_subprocess
 
 
@@ -52,15 +53,8 @@ def _open_system_shell():
     return terminal.run_in_terminal(cmd, cwd, env_overrides, True)
 
 
-def _inside_flatpak():
-    import os
-    import shutil
-
-    return shutil.which("flatpak-spawn") and os.path.isfile("/app/manifest.json")
-
-
 def load_plugin() -> None:
-    if not _inside_flatpak:
+    if not inside_flatpak():
         get_workbench().add_command(
             "OpenSystemShell",
             "tools",

--- a/thonny/plugins/system_shell/__init__.py
+++ b/thonny/plugins/system_shell/__init__.py
@@ -7,7 +7,7 @@ from thonny import get_runner, get_workbench, terminal
 from thonny.common import get_augmented_system_path, get_exe_dirs
 from thonny.editors import get_saved_current_script_filename
 from thonny.languages import tr
-from thonny.misc_utils import inside_flatpak
+from thonny.misc_utils import inside_flatpak, show_command_not_available_in_flatpak_message
 from thonny.running import get_environment_overrides_for_python_subprocess
 
 
@@ -15,6 +15,10 @@ def _open_system_shell():
     """Main task is to modify path and open terminal window.
     Bonus (and most difficult) part is executing a script in this window
     for recommending commands for running given python and related pip"""
+
+    if inside_flatpak():
+        show_command_not_available_in_flatpak_message()
+        return
 
     cwd = get_workbench().get_local_cwd()
 
@@ -54,12 +58,11 @@ def _open_system_shell():
 
 
 def load_plugin() -> None:
-    if not inside_flatpak():
-        get_workbench().add_command(
-            "OpenSystemShell",
-            "tools",
-            tr("Open system shell..."),
-            _open_system_shell,
-            group=80,
-            image="terminal",
-        )
+    get_workbench().add_command(
+        "OpenSystemShell",
+        "tools",
+        tr("Open system shell..."),
+        _open_system_shell,
+        group=80,
+        image="terminal",
+    )

--- a/thonny/running.py
+++ b/thonny/running.py
@@ -65,6 +65,7 @@ from thonny.misc_utils import (
     inside_flatpak,
     running_on_mac_os,
     running_on_windows,
+    show_command_not_available_in_flatpak_message,
 )
 from thonny.ui_utils import CommonDialogEx, select_sequence, show_dialog
 from thonny.workdlg import WorkDialog
@@ -154,19 +155,18 @@ class Runner:
             show_extra_sequences=True,
         )
 
-        if not inside_flatpak():
-            get_workbench().add_command(
-                "run_current_script_in_terminal",
-                "run",
-                tr("Run current script in terminal"),
-                caption="RunT",
-                handler=self._cmd_run_current_script_in_terminal,
-                default_sequence="<Control-t>",
-                extra_sequences=["<<CtrlTInText>>"],
-                tester=self._cmd_run_current_script_in_terminal_enabled,
-                group=35,
-                image="terminal",
-            )
+        get_workbench().add_command(
+            "run_current_script_in_terminal",
+            "run",
+            tr("Run current script in terminal"),
+            caption="RunT",
+            handler=self._cmd_run_current_script_in_terminal,
+            default_sequence="<Control-t>",
+            extra_sequences=["<<CtrlTInText>>"],
+            tester=self._cmd_run_current_script_in_terminal_enabled,
+            group=35,
+            image="terminal",
+        )
 
         get_workbench().add_command(
             "restart",
@@ -412,6 +412,10 @@ class Runner:
         self.execute_current("Run")
 
     def _cmd_run_current_script_in_terminal(self) -> None:
+        if inside_flatpak():
+            show_command_not_available_in_flatpak_message()
+            return
+
         filename = get_saved_current_script_filename()
         if not filename:
             return

--- a/thonny/running.py
+++ b/thonny/running.py
@@ -60,7 +60,12 @@ from thonny.editors import (
     extract_target_path,
 )
 from thonny.languages import tr
-from thonny.misc_utils import construct_cmd_line, running_on_mac_os, running_on_windows
+from thonny.misc_utils import (
+    construct_cmd_line,
+    inside_flatpak,
+    running_on_mac_os,
+    running_on_windows,
+)
 from thonny.ui_utils import CommonDialogEx, select_sequence, show_dialog
 from thonny.workdlg import WorkDialog
 
@@ -149,18 +154,19 @@ class Runner:
             show_extra_sequences=True,
         )
 
-        get_workbench().add_command(
-            "run_current_script_in_terminal",
-            "run",
-            tr("Run current script in terminal"),
-            caption="RunT",
-            handler=self._cmd_run_current_script_in_terminal,
-            default_sequence="<Control-t>",
-            extra_sequences=["<<CtrlTInText>>"],
-            tester=self._cmd_run_current_script_in_terminal_enabled,
-            group=35,
-            image="terminal",
-        )
+        if not inside_flatpak():
+            get_workbench().add_command(
+                "run_current_script_in_terminal",
+                "run",
+                tr("Run current script in terminal"),
+                caption="RunT",
+                handler=self._cmd_run_current_script_in_terminal,
+                default_sequence="<Control-t>",
+                extra_sequences=["<<CtrlTInText>>"],
+                tester=self._cmd_run_current_script_in_terminal_enabled,
+                group=35,
+                image="terminal",
+            )
 
         get_workbench().add_command(
             "restart",


### PR DESCRIPTION
I found a few things to polish up for the Flatpak.
Namely, I've corrected the AppData file so that it can be accepted on Flathub and hidden the `Open system shell...` menu when Thonny is running from within a Flatpak.
The former required documenting releases of Thonny as part of the AppData file, i.e. the `packaging/linux/org.thonny.Thonny.appdata.xml` file.
This information is conveniently shown to the user in app stores.
It would be good to update this file before cutting a new release with at least the version number and date.

I've also updated my example [Flathub fork for Thonny](https://github.com/jwillikers/flathub/tree/org.thonny.Thonny) which should make it easy to submit the app on Flathub since it contains the necessary files.
Since I updated the AppData file in Thonny's own repository, it will be easiest to use the corrected AppData file when it is available in the next release of Thonny.
When that happens, I'll go ahead and update the version in my fork and then it should be ready for a Thonny maintainer to take the files and submit them to Flathub through their own PR.