### PR TITLE
Isolate the user's site packages for the Flatpak

### DIFF
--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -25,7 +25,6 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
-  - --talk-name=org.freedesktop.FileManager1
 modules:
   - name: tcl
     buildsystem: autotools

--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -19,8 +19,8 @@ finish-args:
   # Thonny requires access to serial / USB devices for embedded development.
   - --device=all
 
-  # Thonny stores Python plugins in subdirectories under ~/.local/lib corresponding to the Python / Thonny version.
-  - --filesystem=~/.local/lib
+  # Ensure that extra Python packages, such as Thonny plugins, are installed to a location inside the Flatpak.
+  - --persist=.local/lib
 
   - --share=ipc
   - --share=network


### PR DESCRIPTION
Currently, the Thonny Flatpak uses the user's site packages directory, `~/.local/lib`, on the host system.
Flatpaks should be isolated from alternative installations of the same application on a system.
If Thonny is installed via the system package manager and as a Flatpak, both versions will share the same plugins.
This PR configures the Flatpak installation to use it's own dedicated, persistent directory for Python site packages.
I also removed a permission which doesn't need to be specified explicitly.