### PR TITLE
Include the latest release in the AppData file

### DIFF
--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -10,7 +10,7 @@ Make sure to validate this file before a release using `appstreamcli validate`.
 This can be done as follows.
 
     sudo apt install appstream
-    appstreamcli packaging/linux/org.thonny.Thonny.appdata.xml
+    appstreamcli org.thonny.Thonny.appdata.xml
 
 Flatpak users may find using the dedicated Flatpak more convenient.
 

--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -6,6 +6,17 @@ On Linux, the AppData file, i.e. `org.thonny.Thonny.appdata.xml` for Thonny, con
 This includes information about each release.
 Thus, before cutting a release, it's important to add at least the version of the release and the date to the top of the `releases` section of the AppData file.
 It's also helpful to add a description of the changes the new release brings with it.
+Make sure to validate this file before a release using `appstreamcli validate`.
+This can be done as follows.
+
+    sudo apt install appstream
+    appstreamcli packaging/linux/org.thonny.Thonny.appdata.xml
+
+Flatpak users may find using the dedicated Flatpak more convenient.
+
+    flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    flatpak install --user flathub org.freedesktop.appstream-glib
+    flatpak run org.freedesktop.appstream-glib validate org.thonny.Thonny.appdata.xml
 
 ## Flatpak
 

--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -47,27 +47,36 @@
     <release version="3.3.13" date="2021-07-25">
       <description>
         <p>
-            This version adds a small metadata update relevant only for Linux packagers.
+            This is minor technical update over 3.3.12.
         </p>
       </description>
+    </release>
+    <release version="3.3.12" date="2021-07-25">
+      <description>
+        <p>
+            This is a bug-fix release.
+        </p>
+      </description>
+    </release>
+
     <release version="3.3.11" date="2021-06-25">
       <description>
         <p>
-          This is a bug-fix release.
+            This is a bug-fix release.
         </p>
       </description>
     </release>
     <release version="3.3.10" date="2021-05-18">
       <description>
         <p>
-          This is mainly a bug-fix release with one new feature -- the ability to install pip-compatible packages for MicroPython.
+            This is mainly a bug-fix release with one new feature -- the ability to install pip-compatible packages for MicroPython.
         </p>
       </description>
     </release>
     <release version="3.3.7" date="2021-04-30">
       <description>
         <p>
-          This is mainly a bug-fix release.
+            This is mainly a bug-fix release.
         </p>
       </description>
     </release>

--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -44,6 +44,12 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="3.3.13" date="2021-07-25">
+      <description>
+        <p>
+            This version adds a small metadata update relevant only for Linux packagers.
+        </p>
+      </description>
     <release version="3.3.11" date="2021-06-25">
       <description>
         <p>

--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -48,7 +48,6 @@
       <description>
         <p>
           This is minor technical update over 3.3.12.
-          See https://github.com/thonny/thonny/releases/tag/v3.3.13 for more info
         </p>
       </description>
     </release>
@@ -56,7 +55,6 @@
       <description>
         <p>
           This is a bug-fix release.
-          See https://github.com/thonny/thonny/releases/tag/v3.3.13 for more info
         </p>
       </description>
     </release>


### PR DESCRIPTION
This is just a small addition to the AppData file for Linux.
It just adds the details of the latest Thonny release.