### PR TITLE
Remove permission for user site packages, which is no longer necessary

### DIFF
--- a/packaging/linux/org.thonny.Thonny.Devel.yaml
+++ b/packaging/linux/org.thonny.Thonny.Devel.yaml
@@ -19,9 +19,6 @@ finish-args:
   # Thonny requires access to serial / USB devices for embedded development.
   - --device=all
 
-  # Ensure that extra Python packages, such as Thonny plugins, are installed to a location inside the Flatpak.
-  - --persist=.local/lib
-
   - --share=ipc
   - --share=network
   - --socket=x11


### PR DESCRIPTION
Sorry for yet another PR, but I noticed the Python site-packages are defaulting to the system directory inside the Flatpak now that I've switched to the Sdk as the runtime and updated packaging method.
This is just a minor change to remove unnecessarily mapping the path `~/.local/lib` within the Flatpak.
The Python packages are still persistent, though, and won't be effected by updates to the underlying Flatpak.

The Freedesktop Sdk installs to `/var/data/python` within the Flatpak.
This automatically persists Python packages locally here:
  `~/.var/app/org.thonny.Thonny/data/python`

I believe we don't actually need to do anything else to accommodate the XXL packages.
It looks like Python's wheels install the necessary shared libraries directly in the site-packages directory, using RPATH to link to the right libraries.
It should be easy for users to install packages and plugins in the Flatpak, and no special accommodations are likely to be required for most of the popular plugins as far as I can tell.