### PR TITLE
Update ui_utils.py line 978 to fix issue thonny#659

### DIFF
--- a/thonny/ui_utils.py
+++ b/thonny/ui_utils.py
@@ -975,7 +975,7 @@ class AutoScrollbar(SafeScrollbar):
     def set(self, first, last):
         if float(first) <= 0.0 and float(last) >= 1.0:
             self.grid_remove()
-        elif float(first) > 0.001 or float(last) < 0.009:
+        elif float(first) > 0.001 or float(last) < 0.999:
             # with >0 and <1 it occasionally made scrollbar wobble back and forth
             self.grid()
         ttk.Scrollbar.set(self, first, last)


### PR DESCRIPTION
Issue https://github.com/thonny/thonny/issues/659 describes an issue where the horizontal scroll bar doesn't appear unless the user begins to traverse a long line that extends outside the viewport.

On May 31, 2020 @lurch submitted a fix:
https://github.com/thonny/thonny/issues/659#issuecomment-636466768

This is that fix implemented.