### PR TITLE
Added extra import from logging for logging.error which was used on line 110

### DIFF
--- a/thonny/plugins/mypy/__init__.py
+++ b/thonny/plugins/mypy/__init__.py
@@ -1,7 +1,7 @@
 import os.path
 import re
 import subprocess
-from logging import getLogger, error as log_error
+from logging import getLogger
 from typing import Iterable
 
 from thonny import get_runner, get_workbench, ui_utils
@@ -106,7 +106,7 @@ class MyPyAnalyzer(SubprocessProgramAnalyzer):
                 atts["symbol"] = "mypy-" + atts["kind"]
                 warnings.append(atts)
             else:
-                log_error("Can't parse MyPy line: " + line.strip())
+                logger.error("Can't parse MyPy line: " + line.strip())
 
         self.completion_handler(self, warnings)
 

--- a/thonny/plugins/mypy/__init__.py
+++ b/thonny/plugins/mypy/__init__.py
@@ -1,8 +1,7 @@
 import os.path
 import re
 import subprocess
-import sys
-from logging import getLogger
+from logging import getLogger, error as log_error
 from typing import Iterable
 
 from thonny import get_runner, get_workbench, ui_utils
@@ -107,7 +106,7 @@ class MyPyAnalyzer(SubprocessProgramAnalyzer):
                 atts["symbol"] = "mypy-" + atts["kind"]
                 warnings.append(atts)
             else:
-                logging.error("Can't parse MyPy line: " + line.strip())
+                log_error("Can't parse MyPy line: " + line.strip())
 
         self.completion_handler(self, warnings)
 


### PR DESCRIPTION
A student of mine ran into an internal thonny error where every time she tried to run her code, a NameError would come up because logging wasn't defined on line 110 of the mypy plugin's __init__.py. This change fixes that error by adding an import.

The else branch where the error happens must be hard to reach, because only one student out of a class of ~80 had this bug; I was not able to identify what about her code actually triggered that else, although the one thing that was a bit off was that she had imported the current file within itself.

I ran black on this as well as pytest thonny/tests; I hope it's a small and simple enough change that it doesn't break anything :)