### PR TITLE
Remove shebangs

### DIFF
--- a/thonny/vendored_libs/pipkin/__main__.py
+++ b/thonny/vendored_libs/pipkin/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 MIT License
 

--- a/thonny/vendored_libs/pipkin/__main__.py
+++ b/thonny/vendored_libs/pipkin/__main__.py
@@ -1,3 +1,4 @@
+#/usr/bin/env python3
 """
 MIT License
 


### PR DESCRIPTION
Removing Shebangs to make the file unexecutable as this is causing rpm-linter error