### PR TITLE
Remove shebang

### DIFF
--- a/thonny/vendored_libs/pipkin/proxy.py
+++ b/thonny/vendored_libs/pipkin/proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#/usr/bin/env python3
 """
 MIT License
 


### PR DESCRIPTION
  Removing Shebangs to make the file unexecutable as this is causing rpm-linter error