### PR TITLE
Minor corrections for English help pages

### DIFF
--- a/thonny/plugins/help/assistant.rst
+++ b/thonny/plugins/help/assistant.rst
@@ -9,7 +9,7 @@ to explain it in simpler terms and offers some advice for finding and fixing the
 Sometimes your program may not work as you want even if you don't get any error messages. In this case
 sometimes it helps to investigate the code carefully in order to spot certain bad smells or
 peculiarities, which may lead to discovering the problem. There are two popular tools, which are used
-for such investigations: `Pylint <pylint.pycqa.or>`_ and `Mypy <http://mypy-lang.org/>`_.
+for such investigations: `Pylint <pylint.pycqa.org>`_ and `Mypy <http://mypy-lang.org/>`_.
 
 Mypy tries to detect certain contradictions in your code, for example when a function seems to
 expect an integer argument, but your code calls it with a string. Pylint is not as good with this

--- a/thonny/plugins/help/birdseye.rst
+++ b/thonny/plugins/help/birdseye.rst
@@ -21,4 +21,4 @@ for decorating your functions. Thonny executes Birdseye such that it records inf
 functions.
 
 The local server uses port 7777 by default. If this is used by another application, then configure
-another port (Tools → Options → Debugger) and restart Thonny.
+another port in *Tools → Options → Run & Debug* and restart Thonny.

--- a/thonny/plugins/help/debuggers.rst
+++ b/thonny/plugins/help/debuggers.rst
@@ -33,7 +33,7 @@ If you want to reach a specific part of the code, then you can speed up the
 process by placing your cursor on that line and selecting *Run → Run to cursor*. 
 This makes Thonny automatically step until this line. You can take the command from there.
 
-If you have editor line numbers enabled (Tools → Options → Editor), then you can 
+If you have editor line numbers enabled in *Tools → Options → Editor*, then you can 
 also use **breakpoints**. When you click next to a statement in the editor left margin, a dot
 appears. When you now start the debugger, it doesn't stop before first statement but runs to the 
 statement marked with the dot a.k.a breakpoint. You can place as many breakpoints to your programs as 
@@ -55,10 +55,10 @@ Different styles for showing the call stack
 -------------------------------------------
 By default Thonny uses stacked windows for presenting the call stack. This gives good intuition about 
 the concept, but it may become cumbersome to use. Therefore, since version 3.0 one can choose between 
-two different styles for presenting call stack. In “Tools → Options → Debugger” you can switch to more 
+two different styles for presenting call stack. In *Tools → Options → Run & Debug* you can switch to more 
 traditional style with a separate view for presenting and switching call frames. Note that both 
 styles can be used with both debugging modes.
 
 Birdseye
 --------
-Command *Debug current script (Birdseye)* is explained at a `separate page <birdseye.rst>`_
+Command *Debug current script (Birdseye)* is explained at a `separate page <birdseye.rst>`_.

--- a/thonny/plugins/help/dock.rst
+++ b/thonny/plugins/help/dock.rst
@@ -12,4 +12,4 @@ check it and run your Tkinter program, Thonny performs following magic tricks:
 * It remembers where you position your window. Next time it places the window at the same position.
 * It makes your window stay on top even if you click on Thonny window to start modifying the code. In fact, after your Tkinter window becomes visible, Thonny automatically focuses its own window so that you can continue editing the script without grabbing the mouse. When you're done, just press F5 again and old window gets replaced with the new one.
  
-*Staying on top currently does not work with turtle programs on macOS (https://github.com/thonny/thonny/issues/798)*
+Staying on top currently does not work with turtle programs on macOS (https://github.com/thonny/thonny/issues/798).

--- a/thonny/plugins/help/flask.rst
+++ b/thonny/plugins/help/flask.rst
@@ -12,8 +12,8 @@ Debugging
 ---------
 If you want to step through your Flask program, set a breakpoint inside some function and invoke 
 the debugger (both nicer and faster work, but faster is ... faster). Reload your page and start 
-stepping inside the function. You may want to turn off "Frames in separate windows" (Tools => Options
-=> Run & Debug) for more comfortable operation. 
+stepping inside the function. You may want to turn off "Frames in separate windows" in *Tools → Options
+→ Run & Debug* for more comfortable operation.
 
 Details
 -------

--- a/thonny/plugins/help/modes.rst
+++ b/thonny/plugins/help/modes.rst
@@ -8,7 +8,7 @@ This is the default mode. Nothing much to say about this.
 
 Simple mode
 -----------
-In this mode the menus are hidden, toolbar buttons have captions and Variables view gets automatically opened. 
+In this mode the menus are hidden and toolbar buttons have captions.
 Use a small link in the upper-right corner of the main window to return to regular mode.
 
 Expert mode
@@ -17,6 +17,6 @@ This mode looks almost like regular mode, but has some extra features, which are
 useful for teachers.
 
 * View menu gets an extra item *Full screen* which puts Thonny to full screen.
-* Double clicking on the tab of an editor or view maximizes this editor or view. Unmaximize by double clicking the tab again.
+* Double clicking on the tab of an editor or view maximizes this editor or view. Unmaximize by typing ESC.
 * Tools menu gets an extra item *Open replayer...* which allows replaying user action logs.   
 

--- a/thonny/plugins/help/packages.rst
+++ b/thonny/plugins/help/packages.rst
@@ -10,10 +10,10 @@ With pip on command line
 ------------------------
 #. From "Tools" menu select "Open system shell...". You should get a new terminal window stating the correct name of *pip* command (usually ``pip`` or ``pip3``). In the following I've assumed the command name is ``pip``.
 #. Enter ``pip install <package name>`` (eg. ``pip install pygame``) and press ENTER. You should see *pip* downloading and installing the package and printing a success message.
-#. Close the terminal (optional)
-#. Return to Thonny
-#. Reset interpreter by selecting "Stop/Reset" from "Run menu" (this is required only first time you do pip install)
-#. Start using the package
+#. Close the terminal (optional).
+#. Return to Thonny.
+#. Reset interpreter by selecting "Stop/Restart backend" from "Run" menu (this is required only first time you do pip install).
+#. Start using the package.
 
 .. NOTE::
    The "Open system shell..." menu is not available when running from the Flatpak on Linux.
@@ -45,7 +45,7 @@ Install it and find out where it puts Python executable (*pythonw.exe* in Window
 *python3* or *python* in Linux and Mac).
 
 In Thonny open "Tools" menu and select "Options...". In the options dialog open "Interpreter" 
-tab, click "Select executable" and show the location of Anaconda's Python executable.
+tab and show the location of Anaconda's Python executable.
 
 After you have done this, next time you run your program, it will be run through Anaconda's 
 Python and all the libraries installed there are available.

--- a/thonny/plugins/help/program_arguments.rst
+++ b/thonny/plugins/help/program_arguments.rst
@@ -19,7 +19,6 @@ When you run your program like this, you can access the arguments from ``sys.arg
 Fixing the command line arguments
 ---------------------------------
 If you need to use same set of arguments several times, it may become tedious to construct
-the ``%Run`` by hand. In this case check **Program arguments** in the **View menu**. This 
+the ``%Run`` by hand. In this case check **Program arguments** in the **View** menu. This
 opens a small entry box next to the toolbar buttons. From now on, everything you type in this
 box gets appended to ``%Run <script name>`` each time you press F5.
- 	

--- a/thonny/plugins/help/shell.rst
+++ b/thonny/plugins/help/shell.rst
@@ -14,9 +14,9 @@ to close some parentheses.
 
 Magic commands
 --------------
-If you select "Run => Run current script" or press F5, then you'll see how Thonny inserts a command
+If you select *Run →  Run current script* or press F5, then you'll see how Thonny inserts a command
 starting with ``%Run`` into Shell. Commands starting with ``%`` are called *magic commands* (just 
-like in `IPython <https://ipython.org/>`_ and they perform certain actions, which can't be
+like in `IPython <https://ipython.org/>`_) and they perform certain actions, which can't be
 (easily) expressed as Python commands. Thonny's magic commands usually have
 corresponding menu commands so you don't need write them by hand.
 
@@ -33,7 +33,7 @@ before that and so on. Use Down-key to move in the opposite direction in history
 
 Colored output
 --------------
-If you have your Shell in Terminal emulation mode (see Tools => Options => Shell), then you can
+If you have your Shell in Terminal emulation mode (see *Tools → Options → Shell*), then you can
 use `ANSI codes <https://en.wikipedia.org/wiki/ANSI_escape_code>`_ to produce colored output. 
 
 Try the following example:


### PR DESCRIPTION
While translating the current English help pages I noticed a few typos and outdated references to interface elements.

Most notably, "Debugger" is now "Run & Debug", "Stop/Reset" is now "Stop/Restart backend" and the "Select executable" button no longer exists.

Moreover, I made two minor updates to the description of modes: "simple" mode no longer opens the "Variables" view and "expert" mode only unmaximizes windows by typing ESC.

This pull request fixes them, also adding consistent formatting like *Tools → Options → Run & Debug* .