### PR TITLE
Require saving before using fast debugger

### DIFF
--- a/thonny/running.py
+++ b/thonny/running.py
@@ -351,7 +351,7 @@ class Runner:
         self.execute_via_shell(cmd_line, working_directory)
 
     def execute_editor_content(self, command_name, args):
-        if command_name.lower() == "debug":
+        if command_name.lower() in ["debug", "fastdebug"]:
             messagebox.showinfo(
                 tr("Information"),
                 tr("For debugging the program must be saved first."),


### PR DESCRIPTION
In 0bb3b5fb a check was introduced to ensure that the program is saved before debugging. However, this check currently only catches attempts to run the nice debugger. The fast debugger also requires the file to be saved, so catch that one as well.