### PR TITLE
Enable thonny to open and save files with zenity 3.91+

### DIFF
--- a/thonny/ui_utils.py
+++ b/thonny/ui_utils.py
@@ -2098,8 +2098,6 @@ class _ZenityDialogProvider:
     def asksaveasfilename(cls, **options):
         args = cls._convert_common_options("Save as", **options)
         args.append("--save")
-        if options.get("confirmoverwrite", True):
-            args.append("--confirm-overwrite")
 
         filename = cls._call(args)
         if not filename:
@@ -2124,7 +2122,6 @@ class _ZenityDialogProvider:
         parent = options.get("parent", options.get("master", None))
         if parent is not None:
             args.append("--modal")
-            args.append("--attach=%s" % hex(parent.winfo_id()))
 
         for desc, pattern in options.get("filetypes", ()):
             # zenity requires star before extension
@@ -2143,7 +2140,7 @@ class _ZenityDialogProvider:
 
     @classmethod
     def _call(cls, args):
-        args = ["zenity", "--name=Thonny", "--class=Thonny"] + args
+        args = ["zenity"] + args
         result = subprocess.run(
             args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
         )


### PR DESCRIPTION
Based on the man pages of zenity and my own testing with zenity 3.91 and 3.92 on Fedora Linux 38, this is the minimum required to open and save files in the Gnome environment. Disclaimer: this was crafted using the trial & error method and I can't really tell whether this is a proper way to fix the issue long-term. Any guidance here will be much appreciated.

- Removed `--attach`, `--name` and `--class` options which are no longer recognized.

- Removed the deprecated option `--confirm-overwrite` (man zenity 3.92.0): --confirm-overwrite DEPRECATED; does nothing

Fixes: #2750

