### PR TITLE
Use a tilde to separate pre-release versions in the AppData

### DIFF
--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -51,7 +51,7 @@
         </p>
       </description>
     </release>
-    <release version="4.1.0b1" date="2023-04-23">
+    <release version="4.1.0~b1" date="2023-04-23">
       <description>
         <p>
           Feature pre-release.


### PR DESCRIPTION
This is required for properly ordering the version numbers. Without this, the version ordering is deemed invalid. The tilde character is recommended for this case: https://www.freedesktop.org/software/appstream/docs/chap-AppStream-Misc.html#spec-vercmp-recommendations This causes the Flatpak to fail to build currently: https://buildbot.flathub.org/#/builders/31/builds/3925

AppData can be validated locally according to the instructions here: https://github.com/flathub/flathub/wiki/AppData-Guidelines#use-flathubs-appstream-util