### PR TITLE
cpython_frontend: Support for ~/.virtualenvs directory on unix.

### DIFF
--- a/thonny/assistance.py
+++ b/thonny/assistance.py
@@ -303,7 +303,7 @@ class AssistantView(tktextext.TextFrame):
                     ("em",),
                 )
 
-        #if self.text.get("1.0", "end").strip():
+        # if self.text.get("1.0", "end").strip():
         #    self._append_feedback_link()
 
         if self._exception_info:

--- a/thonny/plugins/cpython_frontend/cp_front.py
+++ b/thonny/plugins/cpython_frontend/cp_front.py
@@ -414,7 +414,8 @@ def _get_interpreters():
             os.path.expanduser("~/anaconda3/bin"),
         ]
 
-        virtualenvwrapper = os.path.join(os.path.expanduser("~/.virtualenvs"), "*/bin")
+        workon_home = os.environ.get("WORKON_HOME", os.path.expanduser("~/.virtualenvs"))
+        virtualenvwrapper = os.path.join(workon_home, "*/bin")
         dirs += glob.glob(virtualenvwrapper)
 
         for dir_ in dirs:

--- a/thonny/plugins/cpython_frontend/cp_front.py
+++ b/thonny/plugins/cpython_frontend/cp_front.py
@@ -1,3 +1,4 @@
+import glob
 import os.path
 import subprocess
 import sys
@@ -412,6 +413,10 @@ def _get_interpreters():
             os.path.expanduser("~/.local/bin"),
             os.path.expanduser("~/anaconda3/bin"),
         ]
+
+        virtualenvwrapper = os.path.join(os.path.expanduser("~/.virtualenvs"), "*/bin")
+        dirs += glob.glob(virtualenvwrapper)
+
         for dir_ in dirs:
             # if the dir_ is just a link to another dir_, skip it
             # (not to show items twice)


### PR DESCRIPTION
This is a first gentle step for #2974 to acknowledge that "~/.virtualenvs" is a standard directory where we might find python binaries managed by virtualenvwrapper and add support for it into Thonny.

It adds a simple glob expansion of the "~/.virtualenvs" directory to find python binaries managed by virtualenvwrapper.

The "allvirtualenv" function backing "lsvirtualenv" for virtualenvwrapper actually *activates* each virtual environment in a sub shell to enumerate them and find their "prompt" or "name". I don't think we need to go this far.

This mirrors [VSCode's Python extension, which scans this directory for interpreters](https://code.visualstudio.com/docs/python/environments#_where-the-extension-looks-for-environments).

This is an attempt at - in light of [pep688](https://peps.python.org/pep-0668/) finding its way into distros - cohesion between VScode, Thonny and user (command-line) Python environments with the least amount of friction.

I plan to use "~/.virtualenvs" as the default home for a "pimoroni" virtual environment on Raspberry Pi OS. This is where our software installers (simple helper scripts for users who don't want to care about Python's idiosyncrasies) will install our Python libraries.

It might also be worth checking the `WORKON_HOME` environment variable, since VSCode also supports this and the default virtualenvwrapper directory can be overridden by the user. There is no precedent I could find for grabbing an environment variable in `cpython_frontend/cp_front.py` however.