### PR TITLE
run PowerShell instead of cmd on Windows

### DIFF
--- a/thonny/terminal.py
+++ b/thonny/terminal.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 
 
-def run_in_terminal(cmd, cwd, env_overrides={}, keep_open=True, title=None):
+def run_in_terminal(cmd, cwd, env_overrides={}, keep_open=True):
     from thonny.running import get_environment_with_overrides
 
     env = get_environment_with_overrides(env_overrides)
@@ -14,7 +14,7 @@ def run_in_terminal(cmd, cwd, env_overrides={}, keep_open=True, title=None):
         cwd = os.getcwd()
 
     if sys.platform == "win32":
-        _run_in_terminal_in_windows(cmd, cwd, env, keep_open, title)
+        _run_in_terminal_in_windows(cmd, cwd, env, keep_open)
     elif sys.platform == "linux":
         _run_in_terminal_in_linux(cmd, cwd, env, keep_open)
     elif sys.platform == "darwin":
@@ -31,7 +31,7 @@ def open_system_shell(cwd, env_overrides={}):
     if sys.platform == "darwin":
         _run_in_terminal_in_macos([], cwd, env_overrides, True)
     elif sys.platform == "win32":
-        cmd = "start cmd"
+        cmd = "start " + _get_windows_terminal_command()
         subprocess.Popen(cmd, cwd=cwd, env=env, shell=True)
     elif sys.platform == "linux":
         cmd = _get_linux_terminal_command()
@@ -54,14 +54,10 @@ def _add_to_path(directory, path):
         return directory + os.pathsep + path
 
 
-def _run_in_terminal_in_windows(cmd, cwd, env, keep_open, title=None):
+def _run_in_terminal_in_windows(cmd, cwd, env, keep_open):
     if keep_open:
-        # Yes, the /K argument has weird quoting. Can't explain this, but it works
-        quoted_args = " ".join(map(lambda s: s if s == "&" else '"' + s + '"', cmd))
-        cmd_line = """start {title} /D "{cwd}" /W cmd /K "{quoted_args}" """.format(
-            cwd=cwd, quoted_args=quoted_args, title='"' + title + '"' if title else ""
-        )
-
+        term_cmd = _get_windows_terminal_command()
+        cmd_line = ["start", term_cmd, "-NoExit", "-Command"] + cmd
         subprocess.Popen(cmd_line, cwd=cwd, env=env, shell=True)
     else:
         subprocess.Popen(cmd, creationflags=subprocess.CREATE_NEW_CONSOLE, cwd=cwd, env=env)
@@ -172,6 +168,17 @@ def _run_in_terminal_in_macos(cmd, cwd, env_overrides, keep_open):
     )
 
     subprocess.Popen(cmd_line, cwd=cwd, shell=True)
+
+
+def _get_windows_terminal_command():
+    import shutil
+
+    if shutil.which("pwsh"):
+        # PowerShell version 6+
+        return "pwsh"
+    else:
+        # Windows PowerShell 5.1
+        return "powershell"
 
 
 def _get_linux_terminal_command():


### PR DESCRIPTION
In Windows 10, PowerShell [replaced][1] Command Prompt (cmd) as the default shell. PowerShell has been [installed by default][2] for over 10 years (since Windows 7 SP1 and Windows Server 2008 R2 SP1). Opening a Terminal in VS Code runs PowerShell by default. However, opening a Terminal in Thonny runs cmd by default. PowerShell is better for classrooms with a mix of Windows, Mac, and Linux computers, because the same commands can be run on all three OS's.

This pull request makes three minor changes to terminal.py:
1. Adds `_get_windows_terminal_command()` to return either `"pwsh"` (if the latest version is installed) or `"powershell"` (the pre-installed version).
2. Modifies `run_in_terminal()` and `_run_in_terminal_in_windows()` to use PowerShell instead of cmd. This change removes the "weird quoting" and relies on `subprocess.Popen()` to correctly quote the arguments.
3. Removes the `title` parameter from `run_in_terminal()`, which could optionally be set for Windows terminals only, but is now obsolete. As far as I can tell, the title was always `None` anyway.

[1]: https://support.microsoft.com/en-us/windows/powershell-is-replacing-command-prompt-fdb690cf-876c-d866-2124-21b6fb29a45f
[2]: https://learn.microsoft.com/en-us/powershell/scripting/windows-powershell/install/installing-windows-powershell?view=powershell-7.3