### PR TITLE
Update appstream metadata

### DIFF
--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -17,14 +17,6 @@
     <p>See the homepage for more information, screenshots and a walk-through video.</p>
   </description>
   
-  <categories>
-    <category>Development</category>
-    <category>Education</category>
-    <category>Debugger</category>
-    <category>IDE</category>
-    <category>ComputerScience</category>
-  </categories>
-  
   <launchable type="desktop-id">org.thonny.Thonny.desktop</launchable>
 
   <url type="homepage">https://thonny.org</url>

--- a/packaging/linux/org.thonny.Thonny.appdata.xml
+++ b/packaging/linux/org.thonny.Thonny.appdata.xml
@@ -6,6 +6,7 @@
   <project_license>MIT</project_license>
   <name>Thonny</name>
   <summary>Python IDE for beginners</summary>
+  <developer_name>Aivar Annamaa</developer_name>
 
   <description>
     <p>Thonny is a simple Python IDE with features useful for learning programming.

--- a/packaging/linux/org.thonny.Thonny.desktop
+++ b/packaging/linux/org.thonny.Thonny.desktop
@@ -7,8 +7,8 @@ Comment=Python IDE for beginners
 Icon=thonny
 StartupWMClass=Thonny
 Terminal=false
-Categories=Development;IDE
-Keywords=programming;education
+Categories=ComputerScience;Debugger;Development;Education;IDE
+Keywords=programming;python
 MimeType=text/x-python;
 Actions=Edit;
 


### PR DESCRIPTION
Add missing `developer_name` attribute to the appstream metadata which is now required.
See the build failure here for reference: https://buildbot.flathub.org/#/builders/28/builds/8761