### PR TITLE
Fix LocalCPythonProxy.compute_mgmt_executable not returning

### DIFF
--- a/thonny/plugins/cpython_frontend/cp_front.py
+++ b/thonny/plugins/cpython_frontend/cp_front.py
@@ -44,7 +44,7 @@ class LocalCPythonProxy(SubprocessProxy):
             get_shell().report_exception()
 
     def compute_mgmt_executable(self):
-        get_workbench().get_option("LocalCPython.executable")
+        return get_workbench().get_option("LocalCPython.executable")
 
     def get_mgmt_executable_validation_error(self) -> Optional[str]:
         if not os.path.isfile(self._mgmt_executable):


### PR DESCRIPTION
Without this change, running thonny from source with

```
$ python3 -m thonny
```

I got this error:

```
10:29:59.503 [MainThread] ERROR   thonny.running: Could not start backend when starting Runner
Traceback (most recent call last):
  File "/Users/razzi/forks/thonny/thonny/running.py", line 176, in start
    self.restart_backend(False, True)
  File "/Users/razzi/forks/thonny/thonny/running.py", line 818, in restart_backend
    self._proxy = backend_class(clean)
                  ^^^^^^^^^^^^^^^^^^^^
  File "/Users/razzi/forks/thonny/thonny/plugins/cpython_frontend/cp_front.py", line 40, in __init__
    super().__init__(clean)
  File "/Users/razzi/forks/thonny/thonny/running.py", line 1144, in __init__
    if ".." in self._mgmt_executable:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

It seems the function LocalCPythonProxy.compute_mgmt_executable was simply not returning.
