### PR TITLE
Fix: Improve compatibility for Python 3.10+ by handling NoneType import

### DIFF
--- a/thonny/lsp_proxy.py
+++ b/thonny/lsp_proxy.py
@@ -1,5 +1,6 @@
 # Adapted from https://github.com/predragnikolic/OLSP/
 
+import sys
 import dataclasses
 import inspect
 import json
@@ -10,11 +11,16 @@ import time
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
-from enum import Enum, StrEnum
+from enum import Enum
 from logging import getLogger
 from queue import Queue
 from turtledemo.penrose import start
-from types import NoneType, UnionType
+if sys.version_info >= (3, 10):
+    from types import NoneType, UnionType
+else:
+    # For Python < 3.10, use the built-in type(None) instead of NoneType
+    NoneType = type(None)
+    from typing import Union as UnionType
 from typing import (
     Any,
     Callable,


### PR DESCRIPTION
Description:
This PR addresses compatibility issues with Python 3.10+ by conditionally importing NoneType and UnionType. For older versions (Python < 3.10), the code now falls back to type(None) and Union from typing.

Changes:

Added a conditional import for NoneType and UnionType based on Python version.
Ensured backward compatibility for Python 3.8 and 3.9.
Issue Reference:
Fixes #3569 

Testing:

Verified functionality on Python 3.8, 3.9, and 3.11.