### PR TITLE
Remove unused and breaking compatibility imports

### DIFF
--- a/thonny/assistance.py
+++ b/thonny/assistance.py
@@ -7,16 +7,13 @@ from dataclasses import dataclass
 from logging import getLogger
 from typing import Dict, Iterator, List, Optional
 
-from thonny import get_workbench, rst_utils
+from thonny import get_workbench
 from thonny.common import read_source
 from thonny.misc_utils import local_path_to_uri
 
 logger = getLogger(__name__)
 
 Suggestion = namedtuple("Suggestion", ["symbol", "title", "body", "relevance"])
-
-_last_feedback_timestamps = {}  # type: Dict[str, str]
-
 
 @dataclass
 class Attachment:

--- a/thonny/backend.py
+++ b/thonny/backend.py
@@ -8,7 +8,6 @@ import sys
 import threading
 import time
 import traceback
-import warnings
 from abc import ABC, abstractmethod
 from logging import getLogger
 from typing import Any, BinaryIO, Callable, Dict, Iterable, List, Optional, Tuple, Union
@@ -34,7 +33,6 @@ from thonny.common import (  # TODO: try to get rid of this
     parse_message,
     read_one_incoming_message_str,
     serialize_message,
-    try_load_modules_with_frontend_sys_path,
     universal_dirname,
 )
 

--- a/thonny/base_file_browser.py
+++ b/thonny/base_file_browser.py
@@ -2,7 +2,7 @@ import os.path
 import shutil
 import time
 import tkinter as tk
-from abc import ABC, abstractmethod
+from abc import ABC
 from logging import getLogger
 from tkinter import messagebox, simpledialog, ttk
 from typing import Any, Dict, List, Optional, Tuple

--- a/thonny/common.py
+++ b/thonny/common.py
@@ -9,7 +9,6 @@ import dataclasses
 import os.path
 import site
 import sys
-import urllib.parse
 from collections import namedtuple
 from dataclasses import dataclass
 from logging import getLogger

--- a/thonny/custom_notebook.py
+++ b/thonny/custom_notebook.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import tkinter as tk
 from logging import getLogger
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from thonny import dnd  # inspired by and very similar to tkinter.dnd
 from thonny.languages import tr

--- a/thonny/editor_helpers.py
+++ b/thonny/editor_helpers.py
@@ -1,7 +1,6 @@
 import tkinter as tk
-import traceback
 from logging import getLogger
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 from thonny import get_workbench, lsp_types
 from thonny.codeview import CodeViewText, SyntaxText, get_syntax_options_for_tag

--- a/thonny/lsp_proxy.py
+++ b/thonny/lsp_proxy.py
@@ -9,11 +9,10 @@ import threading
 import time
 import typing
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, is_dataclass
-from enum import Enum, StrEnum
+from dataclasses import is_dataclass
+from enum import Enum
 from logging import getLogger
 from queue import Queue
-from turtledemo.penrose import start
 from types import NoneType, UnionType
 from typing import (
     Any,

--- a/thonny/misc_utils.py
+++ b/thonny/misc_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import datetime
 import os.path
 import pathlib
 import platform

--- a/thonny/running.py
+++ b/thonny/running.py
@@ -30,7 +30,6 @@ from typing import (  # @UnusedImport; @UnusedImport
     Dict,
     List,
     Optional,
-    Set,
     Tuple,
     Union,
 )

--- a/thonny/shell.py
+++ b/thonny/shell.py
@@ -9,7 +9,7 @@ from _tkinter import TclError
 from dataclasses import dataclass
 from logging import getLogger
 from tkinter import ttk
-from typing import List, Optional, cast
+from typing import List, Optional
 
 from thonny import (
     get_runner,

--- a/thonny/tktextext.py
+++ b/thonny/tktextext.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from tkinter import TclError
 from tkinter import font as tkfont
 from tkinter import ttk
-from typing import Optional
 
 logger = getLogger(__name__)
 

--- a/thonny/venv_dialog.py
+++ b/thonny/venv_dialog.py
@@ -7,10 +7,9 @@ from tkinter import messagebox, ttk
 from typing import Optional
 
 from thonny import get_runner, get_workbench, ui_utils
-from thonny.common import normpath_with_actual_case
 from thonny.languages import tr
 from thonny.misc_utils import inside_flatpak, running_on_windows
-from thonny.ui_utils import MappingCombobox, askdirectory, askopenfilename, set_text_if_different
+from thonny.ui_utils import MappingCombobox, askdirectory, askopenfilename
 from thonny.workdlg import SubprocessDialog
 
 logger = logging.getLogger(__name__)

--- a/thonny/workdlg.py
+++ b/thonny/workdlg.py
@@ -3,7 +3,6 @@ import queue
 import signal
 import subprocess
 import threading
-import time
 import tkinter as tk
 from logging import getLogger
 from tkinter import messagebox, ttk


### PR DESCRIPTION
Have no idea why, but found some unused imports that does not affect anything.

At leat one of them `from turtledemo.penrose import start` won't allow to start project on Python 3.12.3 on ubuntu 24.04