### PR TITLE
Issues 3573 and 3593 fix

### DIFF
--- a/thonny/plugins/find_replace.py
+++ b/thonny/plugins/find_replace.py
@@ -165,7 +165,10 @@ class FindDialog(CommonDialog):
 
         # create bindings
         self.bind("<Escape>", self._ok)
-        self.find_entry_var.trace("w", self._update_button_statuses)
+        try:
+            self.find_entry_var.trace_add("write", lambda *args: self._update_button_statuses())  # tkinter 8.5.
+        except:
+            self.find_entry_var.trace("w", self._update_button_statuses)  # Fallback for older versions.
         self.find_entry.bind("<Return>", self._perform_find, True)
         self.bind("<F3>", self._perform_find, True)
         self.find_entry.bind("<KP_Enter>", self._perform_find, True)


### PR DESCRIPTION
Fixes to issues 3573 and 3593. Related to Find & Replace plugin not working in specific python versions and not working with emojis. Fix involves replacing deprecated trace function of tkinter to a function that exists in tkinter 8.5. New function inside a try block with a fallback to the old code to maintain code integrity