### PR TITLE
Add module-level docstring to mp_front.py for better clarity

### DIFF
--- a/thonny/plugins/micropython/mp_front.py
+++ b/thonny/plugins/micropython/mp_front.py
@@ -1,3 +1,10 @@
+"""MicroPython backend frontend for Thonny.
+
+This module provides helper functions and classes used to load, initialize,
+and interact with MicroPython backends (for example, connecting to a board,
+starting a REPL, and running code remotely). The functions here are helpers
+used by higher-level plugin components in Thonny's MicroPython integration.
+"""
 import dataclasses
 import os
 import shutil


### PR DESCRIPTION
This PR adds a descriptive module-level docstring to thonny/plugins/micropython/mp_front.py.
The new docstring summarizes the purpose of this module and clarifies its role
in the MicroPython backend integration for Thonny.

- Added a clear overview of what mp_front.py does
- No logic or behavior changes — documentation-only update

This improves code readability and helps new contributors understand the file's purpose.
