### PR TITLE
Restore Interpreter page on Fedora 43 via trace_add

### DIFF
--- a/thonny/plugins/backend_config_page.py
+++ b/thonny/plugins/backend_config_page.py
@@ -114,7 +114,7 @@ class BackendConfigurationPage(ConfigurationPage):
         self.columnconfigure(0, weight=1)
         self.rowconfigure(2, weight=1)
 
-        self._combo_variable.trace("w", self._backend_changed)
+        self._combo_variable.trace_add("write", self._backend_changed)
         self._backend_changed()
 
     def _backend_changed(self, *args):

--- a/thonny/plugins/find_replace.py
+++ b/thonny/plugins/find_replace.py
@@ -165,7 +165,7 @@ class FindDialog(CommonDialog):
 
         # create bindings
         self.bind("<Escape>", self._ok)
-        self.find_entry_var.trace("w", self._update_button_statuses)
+        self.find_entry_var.trace_add("write", self._update_button_statuses)
         self.find_entry.bind("<Return>", self._perform_find, True)
         self.bind("<F3>", self._perform_find, True)
         self.find_entry.bind("<KP_Enter>", self._perform_find, True)


### PR DESCRIPTION
The Preferences → Interpreter page failed to render on Fedora 43 (Python 3.14, Tcl/Tk 8.7) because Tk’s legacy “trace variable” API is removed in 8.7.

Note: Code for this change was generated with Cursor IDE.

Fixes: #3724