### PR TITLE
Update Pololu firmware for 260210 release

### DIFF
--- a/data/update_micropython_variants.py
+++ b/data/update_micropython_variants.py
@@ -279,6 +279,10 @@ pololu_variants = [
         "info_url": "https://github.com/pololu/micropython-build/releases/",
         "downloads": [
             {
+                "version": "260210",
+                "url": "https://github.com/pololu/micropython-build/releases/download/260210/micropython-pololu-3pi-2040-robot-v1.27.0-260210.uf2"
+            },
+            {
                 "version": "240117",
                 "url": "https://github.com/pololu/micropython-build/releases/download/240117/micropython-pololu-3pi-2040-robot-v1.22.1-240117.uf2"
             },
@@ -306,6 +310,10 @@ pololu_variants = [
         "family": "rp2",
         "info_url": "https://github.com/pololu/micropython-build/releases/",
         "downloads": [
+            {
+                "version": "260210",
+                "url": "https://github.com/pololu/micropython-build/releases/download/260210/micropython-pololu-zumo-2040-robot-v1.27.0-260210.uf2"
+            },
             {
                 "version": "240117",
                 "url": "https://github.com/pololu/micropython-build/releases/download/240117/micropython-pololu-zumo-2040-robot-v1.22.1-240117.uf2"


### PR DESCRIPTION
This adds the latest 260210 MicroPython v1.27.0 firmware releases for the 3pi+ and Zumo robots from:

https://github.com/pololu/micropython-build/releases/