### PR TITLE
Fix bare except clauses in core modules

### DIFF
--- a/thonny/editor_helpers.py
+++ b/thonny/editor_helpers.py
@@ -95,7 +95,7 @@ class EditorInfoBox(tk.Toplevel):
                 if box.focus_get():
                     # it's alright
                     return
-            except:
+            except Exception:
                 pass
 
         self.hide()

--- a/thonny/workbench.py
+++ b/thonny/workbench.py
@@ -2886,7 +2886,7 @@ class Workbench(tk.Tk):
         finally:
             try:
                 super().destroy()
-            except:
+            except Exception:
                 logger.exception("Problem during close")
                 sys.exit(1)
 

--- a/thonny/workdlg.py
+++ b/thonny/workdlg.py
@@ -429,7 +429,7 @@ class SubprocessDialog(WorkDialog):
         if hasattr(self._proc, "cmd"):
             try:
                 self.append_text(subprocess.list2cmdline(self._proc.cmd) + "\n")
-            except:
+            except Exception:
                 logger.warning("Could not extract cmd (%s)", self._proc.cmd)
         self._start_listening_current_proc()
 


### PR DESCRIPTION
## Problem

This PR fixes 3 instances of bare `except:` clauses in core Thonny modules that could catch system-level exceptions like `KeyboardInterrupt` and `SystemExit`.

## What Changed

Changed `except:` to `except Exception:` in:
- `workbench.py`:2889 - Exception during window destroy (in finally block)
- `workdlg.py`:432 - Error extracting subprocess command
- `editor_helpers.py`:98 - Focus check during info box display

## Why This Matters

Bare except clauses catch **all** exceptions including system-level ones:
- `KeyboardInterrupt` (Ctrl+C) - makes Thonny harder to interrupt
- `SystemExit` (program shutdown) - can prevent clean shutdown
- `GeneratorExit` - can break generator cleanup

The most critical fix is in `workbench.py` where a bare except in the finally block during window destruction could suppress KeyboardInterrupt and then call `sys.exit(1)`, effectively masking the user's shutdown request.

## Testing

The fix maintains identical error handling for regular exceptions while allowing system exceptions to propagate correctly. All existing logging behavior is preserved.

## References

- [PEP 8: Programming Recommendations](https://peps.python.org/pep-0008/#programming-recommendations)
- [Python Anti-Pattern: Bare Except](https://docs.quantifiedcode.com/python-anti-patterns/correctness/catching_exceptions_the_wrong_way.html)