### PR TITLE
Add UI-enhancement, open <untitled> tab when tab bar is clicked

### DIFF
--- a/thonny/custom_notebook.py
+++ b/thonny/custom_notebook.py
@@ -24,6 +24,8 @@ class CustomNotebookTabRow(tk.Frame):
             padx=(0 if master.dynamic_border else 1, 0),
             pady=(0, 1),
         )
+        # define double-click behavior for empty area of tab bar
+        self.filler.bind("<Double-1>", self._on_empty_space_click, True)
         self._insertion_mark = tk.Frame(
             self,
             background=self.notebook.get_label_foreground(),
@@ -92,6 +94,10 @@ class CustomNotebookTabRow(tk.Frame):
     def hide_insertion_mark(self) -> None:
         self._insertion_mark.place_forget()
         self._insertion_index = None
+    
+    def _on_empty_space_click(self, event: tk.Event) -> None:
+        # handle double-click on empty area of tab bar
+        self.notebook.on_empty_space_click(event)
 
 
 class CustomNotebook(tk.Frame):
@@ -366,6 +372,12 @@ class CustomNotebook(tk.Frame):
     def allows_dragging_to_another_notebook(self) -> bool:
         return False
 
+    # define the hook in the generic CustomNotebook, so that it is available for all subclasses without need to define it in each of them
+    def on_empty_space_click(self, event: tk.Event) -> None:
+        """Called when user double-clicks on empty area of tab bar.
+        Subclasses can override this to implement custom behavior."""
+        pass
+    
     def destroy(self):
         self.unbind("<<ThemeChanged>>", self._on_theme_changed_binding)
         super().destroy()

--- a/thonny/editors.py
+++ b/thonny/editors.py
@@ -1062,6 +1062,11 @@ class EditorNotebook(CustomNotebook):
         if shown_files_count == 0:
             self._cmd_new_file()
 
+    # override from parent class to define the logic for double-clicking on empty space of tab bar
+    def on_empty_space_click(self, event: tk.Event) -> None:
+        """Open new file when double-clicking on empty area of tab bar"""
+        self._cmd_new_file()   
+        
     def save_all_named_editors(self):
         all_saved = True
         for editor in self.get_all_editors():


### PR DESCRIPTION
This PR adds UI-enhancements for when the tab bar is double-clicked, a new <untitled> tab opens (VS code style)

Implementation:
- Defined the double click behavior for the tab bar, by defining the **Tkinter** event.
- Defined the double click method in the CustomNotebook class to be override by the subclasses.
- Override the double click method at the EditorNotebook subclass to open a new file, utilizing _cmd_new_file() method.

Tested on Windows.