### PR TITLE
Fix uf2dialog exception on Python 3.14

### DIFF
--- a/thonny/udisks.py
+++ b/thonny/udisks.py
@@ -15,8 +15,7 @@ UDISKS2_BUS_NAME = "org.freedesktop.UDisks2"
 
 
 def list_volumes_sync() -> Sequence[str]:
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(list_volumes())
+    return asyncio.run(list_volumes())
 
 
 async def list_volumes() -> Sequence[str]:


### PR DESCRIPTION
asyncio.get_event_loop() now raises a RuntimeError in Python 3.14 (which is used e.g. on Fedora 43) when no current event loop is set, which breaks list_volumes_sync() when called from uf2dialog.

Replace manual loop handling with asyncio.run(), which is the recommended replacement for running async code from synchronous code and works across all supported Python versions.

References:
https://docs.python.org/3.14/whatsnew/3.14.html#id10

Fixes: #3775