### PR TITLE
fix: correct logger format specifier in _try_load_paramiko

### DIFF
--- a/thonny/backend.py
+++ b/thonny/backend.py
@@ -630,7 +630,7 @@ class SshMixin(UploadDownloadMixin):
         try:
             import paramiko.client
 
-            logger.debug("Could import %", paramiko.client)
+            logger.debug("Could import %s", paramiko.client)
         except ImportError:
             logger.info("Could not import paramiko")
             print(


### PR DESCRIPTION
The debug log message used '%' instead of '%s', which would not correctly format the paramiko.client module in the log output.