### PR TITLE
fix: add missing space in sizeof_fmt YiB fallback

### DIFF
--- a/thonny/misc_utils.py
+++ b/thonny/misc_utils.py
@@ -473,7 +473,7 @@ def sizeof_fmt(num, suffix="B"):
                 return "%d %s%s" % (num, unit, suffix)
             return "%.1f %s%s" % (num, unit, suffix)
         num /= 1024.0
-    return "%.1f%s%s" % (num, "Yi", suffix)
+    return "%.1f %s%s" % (num, "Yi", suffix)
 
 
 class PopenWithOutputQueues(subprocess.Popen):


### PR DESCRIPTION
# Before (broken - outputs "1024.0YiB")
return "%.1f%s%s" % (num, "Yi", suffix)

# After (fixed - outputs "1024.0 YiB")
return "%.1f %s%s" % (num, "Yi", suffix)
