### PR TITLE
Fixed "Cannot run module code or import module" Issue

### DIFF
--- a/thonny/common.py
+++ b/thonny/common.py
@@ -192,9 +192,8 @@ class EOFCommand(CommandToBackend):
 
 
 class ToplevelCommand(CommandToBackend):
-    def __init__(self, name: str, argv: List[str] = [], **kw) -> None:
+    def __init__(self, name: str, **kw) -> None:
         super().__init__(name, **kw)
-        self.argv = argv
 
 
 class DebuggerCommand(CommandToBackend):


### PR DESCRIPTION
Root Cause: ToplevelCommand had a named argv parameter that created a dead self.argv field. The backend everywhere reads cmd.args, but the named parameter was intercepting the value and storing it as self.argv instead, causing module execution to fail.

The Fix: Removed the unused argv named parameter from ToplevelCommand.__init__() so all fields flow through **kw → self.__dict__ consistently.