### PR TITLE
fix: register matplotlib import handler on all platforms, not just macOS

### DIFF
--- a/thonny/plugins/backend/matplotlib_backend.py
+++ b/thonny/plugins/backend/matplotlib_backend.py
@@ -1,7 +1,9 @@
+import logging
 import os.path
-import sys
 
 from thonny.plugins.cpython_backend import get_backend
+
+logger = logging.getLogger(__name__)
 
 local_conf_file = "matplotlibrc"
 user_conf_file1 = os.path.expanduser("~/.config/matplotlib/matplotlibrc")
@@ -29,6 +31,7 @@ def set_default_backend(matplotlib):
             import tkinter  # @UnusedImport
 
             os.environ["MPLBACKEND"] = "TkAgg"
+            logger.debug("Set MPLBACKEND=TkAgg for matplotlib")
         except ImportError:
             pass
 
@@ -36,7 +39,12 @@ def set_default_backend(matplotlib):
 
 
 def load_plugin():
-    if sys.platform == "darwin":
-        # https://github.com/thonny/thonny/issues/676
-        backend = get_backend()
-        backend.add_import_handler("matplotlib", set_default_backend)
+    # Register the import handler on all platforms, not just macOS.
+    # On macOS the MacOSX backend causes window-close issues (#676).
+    # On Linux/Raspberry Pi and Windows, matplotlib may also pick an
+    # unavailable or broken backend (e.g. GTK3Agg, Qt5Agg) when tkinter
+    # is the correct choice inside Thonny.  Setting MPLBACKEND=TkAgg
+    # early prevents ImportError cascades caused by missing backend libs.
+    # https://github.com/thonny/thonny/issues/676
+    backend = get_backend()
+    backend.add_import_handler("matplotlib", set_default_backend)


### PR DESCRIPTION
The fix (
matplotlib_backend.py
):

 Removed the sys.platform == "darwin" guard so MPLBACKEND=TkAgg is set on all platforms when tkinter is available
All existing safeguards are preserved (respects user's MPLBACKEND env var, matplotlibrc files, and the done flag)
Removed unused import sys, added logging for debug visibility