### PR TITLE
fix: prevent AssertionError in open_path_in_system_file_manager on Linux

### DIFF
--- a/thonny/ui_utils.py
+++ b/thonny/ui_utils.py
@@ -1841,9 +1841,12 @@ def open_path_in_system_file_manager(path):
         # -R doesn't allow showing hidden folders
         subprocess.Popen(["open", path])
     elif running_on_linux():
-        subprocess.Popen(["xdg-open", path])
+        try:
+            subprocess.Popen(["xdg-open", path])
+        except Exception as e:
+            logger.warning("Could not open path %s with xdg-open: %s", path, e)
     else:
-        assert running_on_windows()
+        logger.warning("Opening paths in system file manager is not supported on this platform.")
         subprocess.Popen(["explorer", path])
 
 


### PR DESCRIPTION
Currently, open_path_in_system_file_manager in thonny/ui_utils.py falls back to assert running_on_windows() when the OS is neither Windows nor macOS. This causes an AssertionError crash on Linux environments when clicking options like Tools -> Open Thonny data folder.
This PR adds Linux support using xdg-open with proper exception handling to avoid crashes.